### PR TITLE
Add event search test

### DIFF
--- a/packages/core/test/booster-event-search.test.ts
+++ b/packages/core/test/booster-event-search.test.ts
@@ -1,0 +1,62 @@
+import { BoosterConfig, EventSearchParameters, EventSearchResponse } from '@booster-ai/common'
+import { eventSearch } from '../src/booster-event-search'
+import { fake, restore } from 'sinon'
+import { expect } from './expect'
+
+class TestEvent {
+  public constructor(readonly id: string) {}
+  public entityID(): string {
+    return this.id
+  }
+}
+
+class TestNotification {
+  public constructor(readonly id: string) {}
+}
+
+describe('eventSearch function', () => {
+  afterEach(() => {
+    restore()
+  })
+
+  it('instantiates event and notification classes for returned events', async () => {
+    const config = new BoosterConfig('test')
+    const providerSearch = fake.resolves([
+      {
+        requestID: '1',
+        type: TestEvent.name,
+        entity: 'TestEntity',
+        entityID: '42',
+        createdAt: 'now',
+        value: { id: 'e1', entityID: () => '42' },
+      } as EventSearchResponse,
+      {
+        requestID: '2',
+        type: TestNotification.name,
+        entity: 'TestEntity',
+        entityID: '42',
+        createdAt: 'now',
+        value: { id: 'n1' },
+      } as EventSearchResponse,
+      {
+        requestID: '3',
+        type: 'Unknown',
+        entity: 'TestEntity',
+        entityID: '42',
+        createdAt: 'now',
+        value: { id: 'u1' },
+      } as EventSearchResponse,
+    ])
+    config.provider = { events: { search: providerSearch } } as any
+    config.events[TestEvent.name] = { class: TestEvent }
+    config.notifications[TestNotification.name] = { class: TestNotification }
+
+    const params = { entity: 'TestEntity' } as EventSearchParameters
+    const result = await eventSearch(config, params)
+
+    expect(providerSearch).to.have.been.calledOnceWithExactly(config, params)
+    expect(result[0].value).to.be.instanceOf(TestEvent)
+    expect(result[1].value).to.be.instanceOf(TestNotification)
+    expect(result[2].value).to.deep.equal({ id: 'u1' })
+  })
+})


### PR DESCRIPTION
## Summary
- add a new unit test to cover `eventSearch` logic

## Testing
- `rush lint:fix`
- `rush test` *(fails: These operations did not define any work)*

------
https://chatgpt.com/codex/tasks/task_e_6850873b4500832fbdb89ac1d1ae5f56