### PR TITLE
Fix rush tests by enabling phased commands

### DIFF
--- a/common/config/rush/experiments.json
+++ b/common/config/rush/experiments.json
@@ -40,5 +40,5 @@
    * If true, the phased commands feature is enabled. To use this feature, create a "phased" command
    * in common/config/rush/command-line.json.
    */
-  // "phasedCommands": true
+  "phasedCommands": true
 }


### PR DESCRIPTION
## Summary
- enable phased commands experiment in Rush config

## Testing
- `rush lint:fix`
- `rush test` *(fails: These operations did not define any work)*

------
https://chatgpt.com/codex/tasks/task_e_6851891afbd8832f8754b5ac81875f98