### PR TITLE
Fix Verdaccio health check in integration tests

### DIFF
--- a/.github/workflows/integration-e2e.yml
+++ b/.github/workflows/integration-e2e.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           VERDACCIO_AUTH_ENABLED: false
         options: >-
-          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:4873/health || exit 1"
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:4873/ || exit 1"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
## Summary
- point Verdaccio health check at `/` instead of nonexistent `/health`

## Testing
- `npx --yes @microsoft/rush lint:fix`
- `npx --yes @microsoft/rush build`
- `npx --yes @microsoft/rush test`


------
https://chatgpt.com/codex/tasks/task_e_6853096ef5ac832fb33ed203c79deb60