### PR TITLE
Bump eslint-plugin-prettier to 5.5.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: workspace:^3.2.0
         version: link:../core
       '@oclif/core':
-        specifier: 4.3.3
-        version: 4.3.3
+        specifier: 4.4.0
+        version: 4.4.0
       '@oclif/plugin-help':
         specifier: ^6.2.25
         version: 6.2.28
@@ -63,7 +63,7 @@ importers:
         version: link:../../tools/eslint-config
       '@oclif/test':
         specifier: ^4.1.10
-        version: 4.1.13(@oclif/core@4.3.3)
+        version: 4.1.13(@oclif/core@4.4.0)
       '@types/chai':
         specifier: 5.2.2
         version: 5.2.2
@@ -238,7 +238,7 @@ importers:
         version: link:../metadata
       '@effect/cli':
         specifier: 0.63.9
-        version: 0.63.9(@effect/platform@0.85.0(effect@3.16.5))(@effect/printer-ansi@0.41.2(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5))(@effect/printer@0.44.7(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)
+        version: 0.63.9(@effect/platform@0.85.0(effect@3.16.5))(@effect/printer-ansi@0.41.2(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5))(@effect/printer@0.44.7(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)
       '@effect/cluster':
         specifier: ^0.38.14
         version: 0.38.16(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)
@@ -252,14 +252,14 @@ importers:
         specifier: ^0.86.0
         version: 0.86.2(@effect/cluster@0.38.16(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)
       '@effect/platform-node-shared':
-        specifier: ^0.39.14
-        version: 0.39.16(@effect/cluster@0.38.16(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)
+        specifier: ^0.40.2
+        version: 0.40.2(@effect/cluster@0.38.16(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)
       '@effect/printer':
         specifier: 0.44.7
-        version: 0.44.7(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5)
+        version: 0.44.7(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5)
       '@effect/printer-ansi':
         specifier: 0.41.2
-        version: 0.41.2(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5)
+        version: 0.41.2(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5)
       '@effect/rpc':
         specifier: ^0.62.0
         version: 0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5)
@@ -270,8 +270,8 @@ importers:
         specifier: ^0.37.10
         version: 0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5)
       '@effect/typeclass':
-        specifier: 0.35.5
-        version: 0.35.5(effect@3.16.5)
+        specifier: 0.35.8
+        version: 0.35.8(effect@3.16.5)
       effect:
         specifier: 3.16.5
         version: 3.16.5
@@ -662,8 +662,8 @@ importers:
         specifier: ^2.26.0
         version: 2.31.0(eslint@9.29.0)
       eslint-plugin-prettier:
-        specifier: 5.4.1
-        version: 5.4.1(eslint-config-prettier@10.1.5(eslint@9.29.0))(eslint@9.29.0)(prettier@3.5.3)
+        specifier: 5.5.0
+        version: 5.5.0(eslint-config-prettier@10.1.5(eslint@9.29.0))(eslint@9.29.0)(prettier@3.5.3)
       eslint-plugin-unicorn:
         specifier: ~59.0.1
         version: 59.0.1(eslint@9.29.0)
@@ -799,15 +799,6 @@ packages:
       lmdb:
         optional: true
 
-  '@effect/platform-node-shared@0.39.16':
-    resolution: {integrity: sha512-aJ7jVm9V+SEeNumRmHb+TxD0C38uv/1LLfBHB2Qg+xb5UjnZhak8SzwolAgSKkMNDFpAAdF2AlxZ1tO/HfhCiw==}
-    peerDependencies:
-      '@effect/cluster': ^0.38.16
-      '@effect/platform': ^0.84.11
-      '@effect/rpc': ^0.61.15
-      '@effect/sql': ^0.37.12
-      effect: ^3.16.7
-
   '@effect/platform-node-shared@0.40.2':
     resolution: {integrity: sha512-f9FbZN1pTMlR4bTwlR/mER9Qqd1MwMdryn3cz5/lapmXvgrRxQ+vgGS15d286mZeoc6aHtXGEr0GgoPNDFscKw==}
     peerDependencies:
@@ -868,10 +859,10 @@ packages:
       '@effect/platform': ^0.84.11
       effect: ^3.16.7
 
-  '@effect/typeclass@0.35.5':
-    resolution: {integrity: sha512-mWwRnYak9VfXaCSHAW/rO7pXEQuFi8d+gV9TWppftXQQjRmBIjm5YExuycyMVAcprOk1ojXrStoTZ5OU1M8KzA==}
+  '@effect/typeclass@0.35.8':
+    resolution: {integrity: sha512-hDrILuHlFEtiPSADMX9YKicAa7tSDMqJPEMfBdUoE27cUHLg7qnr5EykLQzvBKPhlHAs9DHb5w/fp9WMV6WUpQ==}
     peerDependencies:
-      effect: ^3.16.5
+      effect: ^3.16.8
 
   '@esbuild/aix-ppc64@0.25.5':
     resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
@@ -1334,8 +1325,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oclif/core@4.3.3':
-    resolution: {integrity: sha512-A0mk4nlVE+r34fl91OdglXVPwhhfzM59IhSxnOigqMkwxFgT8z3i2WlUgzmazzvzSccs2KM4N2HkTS3NEvW96g==}
+  '@oclif/core@4.4.0':
+    resolution: {integrity: sha512-wH5g3SLmbRutnr7UzQBSozRFEAZ7U9YGB/wFuBRr0ZghTgv5DE+KQaf6ZtU7iFb9pvkvoVRnT5XheNAtbjRDaQ==}
     engines: {node: '>=18.0.0'}
 
   '@oclif/plugin-help@6.2.28':
@@ -2360,8 +2351,8 @@ packages:
     peerDependencies:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
 
-  eslint-plugin-prettier@5.4.1:
-    resolution: {integrity: sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==}
+  eslint-plugin-prettier@5.5.0:
+    resolution: {integrity: sha512-8qsOYwkkGrahrgoUv76NZi23koqXOGiiEzXMrT8Q7VcYaUISR+5MorIUxfWqYXN0fN/31WbSrxCxFkVQ43wwrA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       '@types/eslint': '>=8.0.0'
@@ -4596,11 +4587,11 @@ snapshots:
 
   '@effect-ts/system@0.57.5': {}
 
-  '@effect/cli@0.63.9(@effect/platform@0.85.0(effect@3.16.5))(@effect/printer-ansi@0.41.2(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5))(@effect/printer@0.44.7(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)':
+  '@effect/cli@0.63.9(@effect/platform@0.85.0(effect@3.16.5))(@effect/printer-ansi@0.41.2(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5))(@effect/printer@0.44.7(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)':
     dependencies:
       '@effect/platform': 0.85.0(effect@3.16.5)
-      '@effect/printer': 0.44.7(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5)
-      '@effect/printer-ansi': 0.41.2(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5)
+      '@effect/printer': 0.44.7(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5)
+      '@effect/printer-ansi': 0.41.2(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5)
       effect: 3.16.5
       ini: 4.1.3
       toml: 3.0.0
@@ -4618,20 +4609,6 @@ snapshots:
       '@effect/platform': 0.85.0(effect@3.16.5)
       effect: 3.16.5
       uuid: 11.1.0
-
-  '@effect/platform-node-shared@0.39.16(@effect/cluster@0.38.16(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)':
-    dependencies:
-      '@effect/cluster': 0.38.16(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)
-      '@effect/platform': 0.85.0(effect@3.16.5)
-      '@effect/rpc': 0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5)
-      '@effect/sql': 0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5)
-      '@parcel/watcher': 2.5.1
-      effect: 3.16.5
-      multipasta: 0.2.5
-      ws: 8.18.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@effect/platform-node-shared@0.40.2(@effect/cluster@0.38.16(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/sql@0.37.12(@effect/experimental@0.48.10(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5))(effect@3.16.5)':
     dependencies:
@@ -4669,20 +4646,20 @@ snapshots:
       msgpackr: 1.11.4
       multipasta: 0.2.5
 
-  '@effect/printer-ansi@0.41.2(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5)':
+  '@effect/printer-ansi@0.41.2(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5)':
     dependencies:
-      '@effect/printer': 0.41.12(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5)
-      '@effect/typeclass': 0.35.5(effect@3.16.5)
+      '@effect/printer': 0.41.12(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5)
+      '@effect/typeclass': 0.35.8(effect@3.16.5)
       effect: 3.16.5
 
-  '@effect/printer@0.41.12(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5)':
+  '@effect/printer@0.41.12(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5)':
     dependencies:
-      '@effect/typeclass': 0.35.5(effect@3.16.5)
+      '@effect/typeclass': 0.35.8(effect@3.16.5)
       effect: 3.16.5
 
-  '@effect/printer@0.44.7(@effect/typeclass@0.35.5(effect@3.16.5))(effect@3.16.5)':
+  '@effect/printer@0.44.7(@effect/typeclass@0.35.8(effect@3.16.5))(effect@3.16.5)':
     dependencies:
-      '@effect/typeclass': 0.35.5(effect@3.16.5)
+      '@effect/typeclass': 0.35.8(effect@3.16.5)
       effect: 3.16.5
 
   '@effect/rpc@0.62.2(@effect/platform@0.85.0(effect@3.16.5))(effect@3.16.5)':
@@ -4703,7 +4680,7 @@ snapshots:
       effect: 3.16.5
       uuid: 11.1.0
 
-  '@effect/typeclass@0.35.5(effect@3.16.5)':
+  '@effect/typeclass@0.35.8(effect@3.16.5)':
     dependencies:
       effect: 3.16.5
 
@@ -5116,7 +5093,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@oclif/core@4.3.3':
+  '@oclif/core@4.4.0':
     dependencies:
       ansi-escapes: 4.3.2
       ansis: 3.17.0
@@ -5139,11 +5116,11 @@ snapshots:
 
   '@oclif/plugin-help@6.2.28':
     dependencies:
-      '@oclif/core': 4.3.3
+      '@oclif/core': 4.4.0
 
-  '@oclif/test@4.1.13(@oclif/core@4.3.3)':
+  '@oclif/test@4.1.13(@oclif/core@4.4.0)':
     dependencies:
-      '@oclif/core': 4.3.3
+      '@oclif/core': 4.4.0
       ansis: 3.17.0
       debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -6222,7 +6199,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
 
-  eslint-plugin-prettier@5.4.1(eslint-config-prettier@10.1.5(eslint@9.29.0))(eslint@9.29.0)(prettier@3.5.3):
+  eslint-plugin-prettier@5.5.0(eslint-config-prettier@10.1.5(eslint@9.29.0))(eslint@9.29.0)(prettier@3.5.3):
     dependencies:
       eslint: 9.29.0
       prettier: 3.5.3

--- a/tools/eslint-config/package.json
+++ b/tools/eslint-config/package.json
@@ -24,7 +24,7 @@
     "eslint": "^9.29.0",
     "eslint-config-prettier": "10.1.5",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-prettier": "5.4.1",
+    "eslint-plugin-prettier": "5.5.0",
     "eslint-plugin-unicorn": "~59.0.1",
     "prettier": "3.5.3"
   },


### PR DESCRIPTION
## Summary
- bump `eslint-plugin-prettier` in eslint config package
- regenerate lock file

## Testing
- `rush lint:fix`
- `rush test`

------
https://chatgpt.com/codex/tasks/task_e_68530ee97b8c832f9579f27b45f615dc