### PR TITLE
Remove provider deprecation notice

### DIFF
--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -212,14 +212,6 @@ export class BoosterConfig {
   }
 
   public set provider(provider: ProviderLibrary) {
-    console.info(`
-      The usage of the 'config.provider' field is deprecated,
-      please use 'config.providerPackage' instead.
-
-      For more information, check out the docs:
-
-      https://docs.boosterframework.com/going-deeper/environment-configuration
-    `)
     this._provider = provider
   }
 


### PR DESCRIPTION
## Summary
- remove console warning about `config.provider` being deprecated

## Testing
- `npx rush lint:fix`
- `npx rush rebuild`
- `npx rush test`


------
https://chatgpt.com/codex/tasks/task_e_68534b9a4090832fb985853384e459c6