### PR TITLE
Update PNPM store and check lint

### DIFF
--- a/e2e/phase2-create-app.sh
+++ b/e2e/phase2-create-app.sh
@@ -27,9 +27,11 @@ cd /work
 
 # Use the default template
 echo "📦 Creating test-app with default template..."
+export CI=true
 npm create booster-ai@latest test-app \
   --template /workspace/templates/default \
-  --description "Test app"
+  --description "Test app" \
+  --non-interactive
 
 APP_DIR="test-app"
 

--- a/packages/create/src/cli.ts
+++ b/packages/create/src/cli.ts
@@ -169,11 +169,14 @@ async function collectProjectInfo(args: string[]): Promise<ProjectConfig> {
   }
 
   // Check if we should skip prompts (any required flags provided or skip flags set)
+  const isCI = process.env.CI === 'true' || process.env.CI === '1' || !!process.env.GITHUB_ACTIONS || !!process.env.GITLAB_CI || !!process.env.JENKINS_URL
   const shouldSkipPrompts =
+    isCI ||
+    flags['non-interactive'] ||
     flags['skip-install'] ||
     flags['skip-git'] ||
     Object.keys(flags).some((key) =>
-      ['description', 'version', 'author', 'homepage', 'license', 'repository', 'package-manager'].includes(key)
+      ['description', 'version', 'author', 'homepage', 'license', 'repository', 'package-manager', 'template'].includes(key)
     )
 
   let config: ProjectConfig
@@ -310,6 +313,8 @@ async function createProject(config: ProjectConfig): Promise<void> {
       license: config.license,
       repository: config.repository,
       boosterVersion: getBoosterVersion(),
+      providerPackageName: '@booster-ai/server', // Default provider
+      VERSION: getBoosterVersion(), // Use same version as boosterVersion
     }
 
     await replaceInAllFiles(targetDir, replacements)

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -16,7 +16,7 @@
     "@boostercloud/metadata-booster": "^{{boosterVersion}}",
     "{{providerPackageName}}-infrastructure": "^{{boosterVersion}}",
     "rimraf": "^5.0.0",
-    "@booster-ai/eslint-config": "^${VERSION}",
+    "@booster-ai/eslint-config": "^{{VERSION}}",
     "mocha": "11.7.0",
     "@types/mocha": "10.0.1",
     "@types/jsonwebtoken": "9.0.1",


### PR DESCRIPTION
```
<!--

Remember to refer to the CONTRIBUTING.md file before sending the PR

- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md%23github-flow
- https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md%23publishing-your-pull-request

- Make sure you followed our Code style https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md%23code-style-guidelines

- Make sure everything works https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md%23getting-the-code

- Run tests 🐛 https://github.com/boostercloud/booster/blob/main/CONTRIBUTING.md%23running-unit-tests

-->

%23%23 Description
This PR fixes the `create-booster-ai` command from entering interactive mode during e2e tests, which caused test failures. It ensures the CLI runs non-interactively in CI environments or when explicit flags are provided, and correctly handles template placeholder replacements.

%23%23 Changes

- Enhanced `create-booster-ai` CLI's `shouldSkipPrompts` logic to detect CI environments, the `--non-interactive` flag, and the `--template` flag.
- Updated the `e2e/phase2-create-app.sh` script to explicitly set `CI=true` and use the `--non-interactive` flag.
- Corrected template placeholder syntax in `templates/default/package.json` and added missing replacements for `providerPackageName` and `VERSION` in `packages/create/src/cli.ts`.

%23%23 Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [ ] Updated documentation accordingly

<!-- 
%23%23 Additional information

Here you can add any additional information about your PR

For example:

- Reference issue number

- Mention any changes or concerns you may have about this PR

- Reference links to any resource that help clarifying the intent and goals of the change.

-->
```