### PR TITLE
Bump faker to 9.9.0

### DIFF
--- a/adapters/nedb/event-store/package.json
+++ b/adapters/nedb/event-store/package.json
@@ -45,7 +45,7 @@
     "@types/sinon-chai": "4.0.0",
     "chai": "5.2.0",
     "chai-as-promised": "8.0.1",
-    "@faker-js/faker": "7.6.0",
+    "@faker-js/faker": "9.9.0",
     "mocha": "11.7.1",
     "nyc": "17.1.0",
     "rimraf": "6.0.1",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: workspace:^0.0.1
         version: link:../../../tools/eslint-config
       '@faker-js/faker':
-        specifier: 7.6.0
-        version: 7.6.0
+        specifier: 9.9.0
+        version: 9.9.0
       '@types/chai':
         specifier: 5.2.2
         version: 5.2.2
@@ -126,8 +126,8 @@ importers:
         specifier: workspace:^0.0.1
         version: link:../../tools/eslint-config
       '@faker-js/faker':
-        specifier: 7.6.0
-        version: 7.6.0
+        specifier: 9.9.0
+        version: 9.9.0
       '@oclif/test':
         specifier: 4.1.10
         version: 4.1.10(@oclif/core@4.4.0)
@@ -223,8 +223,8 @@ importers:
         specifier: workspace:^0.0.1
         version: link:../metadata
       '@faker-js/faker':
-        specifier: 7.6.0
-        version: 7.6.0
+        specifier: 9.9.0
+        version: 9.9.0
       '@types/chai':
         specifier: 5.2.2
         version: 5.2.2
@@ -365,8 +365,8 @@ importers:
         specifier: workspace:^0.0.1
         version: link:../../tools/eslint-config
       '@faker-js/faker':
-        specifier: 7.6.0
-        version: 7.6.0
+        specifier: 9.9.0
+        version: 9.9.0
       '@types/chai':
         specifier: 5.2.2
         version: 5.2.2
@@ -560,8 +560,8 @@ importers:
         specifier: workspace:^0.0.1
         version: link:../../tools/eslint-config
       '@faker-js/faker':
-        specifier: 7.6.0
-        version: 7.6.0
+        specifier: 9.9.0
+        version: 9.9.0
       '@types/chai':
         specifier: 5.2.2
         version: 5.2.2
@@ -642,8 +642,8 @@ importers:
         specifier: workspace:^0.0.1
         version: link:../../tools/eslint-config
       '@faker-js/faker':
-        specifier: 7.6.0
-        version: 7.6.0
+        specifier: 9.9.0
+        version: 9.9.0
       '@types/chai':
         specifier: 5.2.2
         version: 5.2.2
@@ -1104,9 +1104,9 @@ packages:
     resolution: {integrity: sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@faker-js/faker@7.6.0':
-    resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
-    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+  '@faker-js/faker@9.9.0':
+    resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@fastify/ajv-compiler@4.0.2':
     resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
@@ -4824,7 +4824,7 @@ snapshots:
       '@eslint/core': 0.15.0
       levn: 0.4.1
 
-  '@faker-js/faker@7.6.0': {}
+  '@faker-js/faker@9.9.0': {}
 
   '@fastify/ajv-compiler@4.0.2':
     dependencies:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
     "chai": "5.2.0",
     "chai-as-promised": "8.0.1",
     "copyfiles": "2.3.0",
-    "@faker-js/faker": "7.6.0",
+    "@faker-js/faker": "9.9.0",
     "fancy-test": "3.0.1",
     "mocha": "11.7.1",
     "nyc": "17.1.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -62,7 +62,7 @@
     "sinon-chai": "4.0.0",
     "ts-node": "10.9.1",
     "typescript": "5.8.3",
-    "@faker-js/faker": "7.6.0",
+    "@faker-js/faker": "9.9.0",
     "fast-check": "4.1.1",
     "graphql": "16.6.0"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,7 @@
     "chai": "5.2.0",
     "chai-as-promised": "8.0.1",
     "cross-env": "7.0.3",
-    "@faker-js/faker": "7.6.0",
+    "@faker-js/faker": "9.9.0",
     "mocha": "11.7.1",
     "mock-jwks": "3.3.5",
     "nyc": "17.1.0",

--- a/packages/server-infrastructure/package.json
+++ b/packages/server-infrastructure/package.json
@@ -57,7 +57,7 @@
     "@types/sinon-chai": "4.0.0",
     "chai": "5.2.0",
     "chai-as-promised": "8.0.1",
-    "@faker-js/faker": "7.6.0",
+    "@faker-js/faker": "9.9.0",
     "mocha": "11.7.1",
     "nyc": "17.1.0",
     "rimraf": "6.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -53,7 +53,7 @@
     "@types/sinon-chai": "4.0.0",
     "chai": "5.2.0",
     "chai-as-promised": "8.0.1",
-    "@faker-js/faker": "7.6.0",
+    "@faker-js/faker": "9.9.0",
     "mocha": "11.7.1",
     "nyc": "17.1.0",
     "rimraf": "6.0.1",


### PR DESCRIPTION
## Summary
- update @faker-js/faker across all packages

## Testing
- `rush lint:fix`
- `rush rebuild`
- `rush test` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_e_68767994e998832fa078ec2237ea96a9