### PR TITLE
Add tsc type check before mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ You can join the conversation and start contributing in any of the following way
 Please refer to [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more details. Pull requests are welcome. For major changes, please
 open an issue first to discuss what you would like to change.
 
+# Testing
+
+Run `rush test` to execute the unit tests across all packages. Each package's test script
+first runs `tsc --noEmit` before invoking Mocha, so the suite fails fast if TypeScript
+compilation errors are detected.
+
 # License
 
 The Booster Framework is licensed under the Apache License, Version 2.0. See the [LICENSE](LICENSE) file for more details.

--- a/adapters/nedb/event-store/package.json
+++ b/adapters/nedb/event-store/package.json
@@ -30,7 +30,7 @@
     "build": "tsc -b tsconfig.json",
     "clean": "rimraf ./dist tsconfig.tsbuildinfo",
     "prepack": "tsc -b tsconfig.json",
-    "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
+    "test": "tsc --noEmit && nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "bugs": {
     "url": "https://github.com/theam/magek/issues"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -89,7 +89,7 @@
     "clean": "rimraf ./dist tsconfig.tsbuildinfo",
     "prepack": "tsc -b tsconfig.json",
     "test:cli": "npm run test",
-    "test": "nyc --extension .ts mocha --forbid-only  \"test/**/*.test.ts\""
+    "test": "tsc --noEmit && nyc --extension .ts mocha --forbid-only  \"test/**/*.test.ts\""
   },
   "types": "lib/index.d.ts"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -26,7 +26,7 @@
     "build": "tsc -b tsconfig.json",
     "clean": "rimraf ./dist tsconfig.tsbuildinfo",
     "test:helpers": "npm run test",
-    "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
+    "test": "tsc --noEmit && nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "prepack": "tsc -b tsconfig.json"
   },
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "clean": "rimraf ./dist tsconfig.tsbuildinfo",
     "prepack": "tsc -b tsconfig.json",
     "test:core": "npm run test",
-    "test": "cross-env BOOSTER_ENV=test nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\" 2>&1"
+    "test": "tsc --noEmit && cross-env BOOSTER_ENV=test nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\" 2>&1"
   },
   "bugs": {
     "url": "https://github.com/boostercloud/booster/issues"

--- a/packages/server-infrastructure/package.json
+++ b/packages/server-infrastructure/package.json
@@ -41,7 +41,7 @@
     "clean": "rimraf ./dist tsconfig.tsbuildinfo",
     "prepack": "tsc -b tsconfig.json",
     "test:provider-local-infrastructure": "npm run test",
-    "test": "BOOSTER_ENV=test nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
+    "test": "tsc --noEmit && BOOSTER_ENV=test nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "bugs": {
     "url": "https://github.com/boostercloud/booster/issues"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -38,7 +38,7 @@
     "clean": "rimraf ./dist tsconfig.tsbuildinfo",
     "prepack": "tsc -b tsconfig.json",
     "test:provider-local": "npm run test",
-    "test": "BOOSTER_ENV=test nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
+    "test": "tsc --noEmit && BOOSTER_ENV=test nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "bugs": {
     "url": "https://github.com/boostercloud/booster/issues"


### PR DESCRIPTION
## Summary
- run `tsc --noEmit` before unit tests
- mention type checking in README test instructions

## Testing
- `npx --yes rush lint:fix`
- `npx --yes rush test -t @booster-ai/common`

------
https://chatgpt.com/codex/tasks/task_e_68792d6ef000832fafeac78bf75b0838