### PR TITLE
refactor(core): remove deprecated Returns decorator

### DIFF
--- a/packages/core/src/decorators/command.ts
+++ b/packages/core/src/decorators/command.ts
@@ -1,12 +1,10 @@
  
 import { Magek } from '../magek'
 import {
-  Class,
   CommandAuthorizer,
   CommandFilterHooks,
   CommandInterface,
   CommandRoleAccess,
-  Register,
 } from '@magek/common'
 import { getClassMetadata } from './metadata'
 import { MagekAuthorizer } from '../authorizer'
@@ -38,40 +36,3 @@ export function Command(
   }
 }
 
-/**
- * Decorator to register a command class method as a
- * command handler function.
- *
- * @param commandClass The command that this method will handle
- *
- * @deprecated [EOL v3] The method is not needed anymore and will be removed in future versions
- *
- * TODO Remove this method as it's not needed
- */
-export function Returns<TReturn>(
-  returnClass: Class<TReturn>
-): <TCommand>(
-  commandClass: Class<TCommand>,
-  methodName: string,
-  methodDescriptor: TypedPropertyDescriptor<
-    (command: TCommand, register: Register) => Promise<PrimitiveTypeOf<TReturn>>
-  >
-) => void {
-  console.error(`
-    The usage of the '@Returns' annotation is deprecated,
-    You may return any type without annotating the method
-
-    For more information, check out the docs:
-
-    https://docs.magek.ai/architecture/command#returning-a-value
-  `)
-  return (commandClass) => {}
-}
-
-type PrimitiveTypeOf<TReturn> = TReturn extends Boolean
-  ? boolean
-  : TReturn extends Number
-  ? number
-  : TReturn extends String
-  ? string
-  : TReturn


### PR DESCRIPTION
## Summary
- remove deprecated @Returns decorator from command decorators

## Testing
- `rush lint:fix`
- `rush build`
- `rush test`


------
https://chatgpt.com/codex/tasks/task_e_6890d3009ee4832f8f16a99dfe74d658