### PR TITLE
refactor(core): remove deprecated token verifier env loader

### DIFF
--- a/packages/core/src/magek.ts
+++ b/packages/core/src/magek.ts
@@ -18,7 +18,6 @@ import { MagekEntityMigrated } from './core-concepts/data-migration/events/entit
 import { MagekDataMigrationEntity } from './core-concepts/data-migration/entities/data-migration-entity'
 import { MagekDataMigrationStarted } from './core-concepts/data-migration/events/data-migration-started'
 import { MagekDataMigrationFinished } from './core-concepts/data-migration/events/data-migration-finished'
-import { JwksUriTokenVerifier, JWT_ENV_VARS } from './services/token-verifiers'
 import { MagekAuthorizer } from './authorizer'
 import { MagekEntityTouched } from './core-concepts/touch-entity/events/entity-touched'
 import { readModelSearcher } from './services/read-model-searcher'
@@ -70,7 +69,6 @@ export class Magek {
     this.config.userProjectRootPath = projectRootPath
     Importer.importUserProjectFiles(codeRootPath)
     this.configureMagekConcepts()
-    this.loadTokenVerifierFromEnv()
     this.config.validate()
     const args = process.argv
     if (process.env['MAGEK_CLI_HOOK']?.trim() !== 'true') {
@@ -180,28 +178,6 @@ export class Magek {
     }
   }
 
-  /**
-   * TODO: We're loading tokenVerifier options from environment variables here for backwards
-   * compatibility reasons, but the preferred way to initialize the project token verifiers
-   * is by setting an implementation of the `TokenVerifier` interface in the project's config.
-   * The Authentication Magek Rocket for AWS uses this initialization mechanism.
-   *
-   * @deprecated [EOL v3] Please set your own implementation of the `TokenVerifier` interface in the project config.
-   */
-  private static loadTokenVerifierFromEnv(): void {
-    const JWT_ISSUER = process.env[JWT_ENV_VARS.JWT_ISSUER]
-    const JWKS_URI = process.env[JWT_ENV_VARS.JWKS_URI]
-    const ROLES_CLAIM = process.env[JWT_ENV_VARS.ROLES_CLAIM]
-    if (JWT_ISSUER && JWKS_URI && ROLES_CLAIM) {
-      console.warn(
-        'Deprecation notice: Implicitly loading the JWT token verifier options from default environment variables is deprecated.' +
-          " Please set your application's `config.tokenVerifiers` options explicitly in your `src/config/config.ts` file."
-      )
-      this.config.tokenVerifiers.push(
-        new JwksUriTokenVerifier(JWT_ISSUER, JWKS_URI, ROLES_CLAIM)
-      )
-    }
-  }
 }
 
 function checkAndGetCurrentEnv(): string {

--- a/packages/core/src/services/token-verifiers/jwks-uri-token-verifier.ts
+++ b/packages/core/src/services/token-verifiers/jwks-uri-token-verifier.ts
@@ -2,17 +2,6 @@ import { DecodedToken } from '@magek/common'
 import { getJwksClient, getKeyWithClient, verifyJWT } from './utilities'
 import { RoleBasedTokenVerifier } from './role-based-token-verifier'
 
-/**
- * Environment variables that are used to configure a default JWKs URI Token Verifier
- *
- * @deprecated [EOL v3] Explicitly initialize the JWKs URI Token Verifier in the project config.
- */
-export const JWT_ENV_VARS = {
-  JWT_ISSUER: 'JWT_ISSUER',
-  JWKS_URI: 'JWKS_URI',
-  ROLES_CLAIM: 'ROLES_CLAIM',
-}
-
 export class JwksUriTokenVerifier extends RoleBasedTokenVerifier {
   public constructor(readonly issuer: string, readonly jwksUri: string, rolesClaim?: string) {
     super(rolesClaim)

--- a/packages/core/test/magek.test.ts
+++ b/packages/core/test/magek.test.ts
@@ -13,7 +13,6 @@ import {
 } from '@magek/common'
 import { EventStore } from '../src/services/event-store'
 import { faker } from '@faker-js/faker'
-import { JwksUriTokenVerifier } from '../src/services/token-verifiers'
 import { afterEach } from 'mocha'
 import { createMockEventStoreAdapter } from './helpers/event-store-adapter-helper'
 import { createMockReadModelStoreAdapter } from './helpers/read-model-store-adapter-helper'
@@ -400,46 +399,4 @@ describe('the `Magek` class', () => {
     })
   })
 
-  describe('The `loadTokenVerifierFromEnv` function', () => {
-    context('when the JWT_ENV_VARS are set', () => {
-      beforeEach(() => {
-        process.env.JWT_ISSUER = 'JWT_ISSUER_VALUE'
-        process.env.JWKS_URI = 'JWKS_URI_VALUE'
-        process.env.ROLES_CLAIM = 'ROLES_CLAIM_VALUE'
-      })
-
-      afterEach(() => {
-        delete process.env.JWT_ISSUER
-        delete process.env.JWKS_URI
-        delete process.env.ROLES_CLAIM
-
-        Magek.config.tokenVerifiers = []
-      })
-
-      it('does alter the token verifiers config', () => {
-        expect(Magek.config.tokenVerifiers).to.be.empty
-
-        const magek = Magek as any
-        magek.loadTokenVerifierFromEnv()
-
-        const tokenVerifierConfig = Magek.config.tokenVerifiers
-        expect(tokenVerifierConfig.length).to.be.equal(1)
-        expect(tokenVerifierConfig[0]).to.be.an.instanceOf(JwksUriTokenVerifier)
-        expect((tokenVerifierConfig[0] as JwksUriTokenVerifier).issuer).to.be.equal('JWT_ISSUER_VALUE')
-        expect((tokenVerifierConfig[0] as JwksUriTokenVerifier).jwksUri).to.be.equal('JWKS_URI_VALUE')
-        expect((tokenVerifierConfig[0] as JwksUriTokenVerifier).rolesClaim).to.be.equal('ROLES_CLAIM_VALUE')
-      })
-    })
-
-    context('when the JWT_ENV_VARS are not set', () => {
-      it('does not alter the token verifiers config', () => {
-        expect(Magek.config.tokenVerifiers).to.be.empty
-
-        const magek = Magek as any
-        magek.loadTokenVerifierFromEnv()
-
-        expect(Magek.config.tokenVerifiers).to.be.empty
-      })
-    })
-  })
 })


### PR DESCRIPTION
## Summary
- remove environment-based token verifier initialization
- drop unused JWT_ENV_VARS constant and its tests

## Testing
- `rush lint:fix`
- `rush rebuild`
- `rush test`


------
https://chatgpt.com/codex/tasks/task_e_6891279a3e8c832faaf9dd9a0f383841