### PR TITLE
refactor(metadata): use ts-morph re-export for TypeScript API

### DIFF
--- a/packages/metadata/src/metadata-extractors.ts
+++ b/packages/metadata/src/metadata-extractors.ts
@@ -1,8 +1,14 @@
  
 
-import { ClassDeclaration, ClassInstancePropertyTypes, createWrappedNode, Node, SyntaxKind, Type } from 'ts-morph'
-// TODO: Import properly
-import * as ts from 'typescript'
+import {
+  ClassDeclaration,
+  ClassInstancePropertyTypes,
+  createWrappedNode,
+  Node,
+  SyntaxKind,
+  Type,
+  ts,
+} from 'ts-morph'
 import { TypeGroup } from './metadata-types'
 
 export interface TypeInfo {


### PR DESCRIPTION
## Summary
- refactor metadata extractor to import `ts` namespace from `ts-morph`

## Testing
- `rush lint:fix`
- `rush test`


------
https://chatgpt.com/codex/tasks/task_e_689256356b98832fb65da249ac764e5c