### PR TITLE
refactor(common,core): keep findById and remove deprecation

### DIFF
--- a/packages/common/src/searcher.ts
+++ b/packages/common/src/searcher.ts
@@ -97,15 +97,11 @@ export class Searcher<
     return this as SearcherAfterPaginatedVersion<TObject, TSingleResult, TPaginated>
   }
 
-  /**
-   * @deprecated [EOL v3] Use searchOne instead
-   */
   public async findById(id: UUID, sequenceKey?: SequenceKey): Promise<TObject | ReadOnlyNonEmptyArray<TObject>> {
     return this.finderByKeyFunction(this.objectClass, id, sequenceKey)
   }
 
   public async searchOne(): Promise<TSingleResult | undefined> {
-    // TODO: If there is only an ID filter with one value, this should call to `findById`
     const searchResult = await this.searcherFunction(
       this.objectClass,
       this.filters,


### PR DESCRIPTION
## Summary
- restore standalone `findById` on Searcher without deprecation notice
- revert read model reader to invoke the Searcher's `findById`
- clean up associated tests

## Testing
- `rush lint:fix`
- `rush test`


------
https://chatgpt.com/codex/tasks/task_e_68926a29f5e4832fb9b4a2bcc4cda11c