### PR TITLE
refactor(core): remove deprecated triggerScheduledCommand export

### DIFF
--- a/docs/10_going-deeper/data-migrations.md
+++ b/docs/10_going-deeper/data-migrations.md
@@ -177,7 +177,7 @@ export {
   graphQLDispatcher,
   health,
   notifySubscribers,
-  triggerScheduledCommand,
+  triggerScheduledCommands,
   rocketDispatcher,
 } from '@magek/core'
 

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -72,7 +72,7 @@ export class MagekConfig {
   public readonly sensorHealthHandler: string = path.join(this.codeRelativePath, 'index.health')
   public readonly scheduledTaskHandler: string = path.join(
     this.codeRelativePath,
-    'index.triggerScheduledCommand'
+    'index.triggerScheduledCommands'
   )
   public readonly notifySubscribersHandler: string = path.join(this.codeRelativePath, 'index.notifySubscribers')
   public readonly rocketDispatcherHandler: string = path.join(this.codeRelativePath, 'index.rocketDispatcher')

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,11 +52,6 @@ export async function triggerScheduledCommands(rawRequest: unknown): Promise<voi
 }
 
 /**
- * @deprecated [EOL v3] Please use `triggerScheduledCommands` instead.
- */
-export const triggerScheduledCommand = triggerScheduledCommands
-
-/**
  * Notifies subscribers of a new update on a read model
  *
  * @param rawRequest A provider-specific representation of the request to notify subscribers.

--- a/packages/server-infrastructure/src/scheduler.ts
+++ b/packages/server-infrastructure/src/scheduler.ts
@@ -7,13 +7,13 @@ interface ScheduledCommandInfo {
 }
 
 export function configureScheduler(config: MagekConfig, userProject: any): void {
-  const triggerScheduleCommand = userProject['triggerScheduledCommand']
+  const triggerScheduledCommands = userProject['triggerScheduledCommands']
   Object.keys(config.scheduledCommandHandlers)
     .map((scheduledCommandName) => buildScheduledCommandInfo(config, scheduledCommandName))
     .filter((scheduledCommandInfo) => scheduledCommandInfo.metadata.scheduledOn)
     .forEach((scheduledCommandInfo) => {
       scheduler.scheduleJob(scheduledCommandInfo.name, createCronExpression(scheduledCommandInfo.metadata), () => {
-        triggerScheduleCommand({ typeName: scheduledCommandInfo.name })
+        triggerScheduledCommands({ typeName: scheduledCommandInfo.name })
       })
     })
 }

--- a/templates/default/src/index.ts
+++ b/templates/default/src/index.ts
@@ -7,7 +7,7 @@ export {
   graphQLDispatcher,
   notifySubscribers,
   health,
-  triggerScheduledCommand,
+  triggerScheduledCommands,
   rocketDispatcher,
 } from '@magek/core'
 


### PR DESCRIPTION
## Summary
- remove deprecated `triggerScheduledCommand` alias and switch references to `triggerScheduledCommands`
- update scheduler, config, templates, and docs accordingly

## Testing
- `rush lint:fix`
- `rush rebuild`
- `rush test`


------
https://chatgpt.com/codex/tasks/task_e_689390b92398832fbcb49be90d3da40a