### PR TITLE
build: upgrade pnpm to 10.14.0

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -9,7 +9,7 @@ RUN git config --global user.email "test@example.com" && \
     git config --global init.defaultBranch main
 
 # Install Verdaccio and pnpm globally
-RUN npm install -g verdaccio@5 pnpm@10.12.4
+RUN npm install -g verdaccio@5 pnpm@10.14.0
 
 # Set working directory
 WORKDIR /work

--- a/rush.json
+++ b/rush.json
@@ -26,7 +26,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "10.12.4",
+  "pnpmVersion": "10.14.0",
 
   // "npmVersion": "6.14.15",
   // "yarnVersion": "1.9.4",


### PR DESCRIPTION
## Summary
- bump pnpm to 10.14.0 in rush config
- align e2e Dockerfile with new pnpm version

## Testing
- `rush lint:fix`
- `rush test` *(fails: Cannot find module '@magek/metadata')*


------
https://chatgpt.com/codex/tasks/task_e_6894bf24c350832fb242092a3ec7b8f2