### PR TITLE
refactor: drop effect-based config tag

### DIFF
--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -28,7 +28,6 @@ import { RocketDescriptor, RocketFunction } from './rockets'
 import { DEFAULT_SENSOR_HEALTH_CONFIGURATIONS, HealthIndicatorMetadata, Logger, SensorConfiguration } from '.'
 import { TraceConfiguration } from './instrumentation/trace-types'
 import { AzureConfiguration, DEFAULT_CHUNK_SIZE } from './provider/azure-configuration'
-import { Context } from 'effect'
 
 /**
  * Class used by external packages that needs to get a representation of
@@ -276,7 +275,6 @@ export class MagekConfig {
   }
 }
 
-export const MagekConfigTag = Context.GenericTag<MagekConfig>('MagekConfig')
 
 interface ResourceNames {
   applicationStack: string

--- a/packages/core/src/injectable/index.ts
+++ b/packages/core/src/injectable/index.ts
@@ -1,11 +1,10 @@
  
-import { MagekConfig } from '@magek/common'
 import { PlatformError } from '@effect/platform/Error'
 import { CliApp, Command } from '@effect/cli'
 import { RunMain } from '@effect/platform/Runtime'
 import { Effect, Layer, Types } from 'effect'
 
-export type Context = MagekConfig | CliApp.CliApp.Environment
+export type Context = CliApp.CliApp.Environment
 export type Error = PlatformError
 
 export interface Injectable {

--- a/packages/core/src/magek.ts
+++ b/packages/core/src/magek.ts
@@ -1,7 +1,6 @@
 import {
   createInstance,
   MagekConfig,
-  MagekConfigTag,
   Class,
   EntityInterface,
   EventDeleteParameters,
@@ -91,7 +90,6 @@ export class Magek {
         }),
         // TODO: Improve error messages
         Effect.provide(provider),
-        Effect.provideService(MagekConfigTag, this.config),
         runner
       )
     }


### PR DESCRIPTION
## Summary
- simplify config by removing Effect Context tag
- adjust Magek startup to run without providing config tag
- narrow CLI injectable context to exclude config

## Testing
- `rush lint:fix`
- `rush rebuild`
- `rush test`


------
https://chatgpt.com/codex/tasks/task_e_68968e89adf0832f8cd37313113e76ab