### PR TITLE
refactor(cli): infer package manager with promise-based fs

### DIFF
--- a/packages/cli/src/services/package-manager/live.impl.ts
+++ b/packages/cli/src/services/package-manager/live.impl.ts
@@ -1,5 +1,3 @@
-import { FileSystemService } from '../file-system'
-import { ProcessService } from '../process'
 import { PackageManagerService } from '.'
 import { Effect, Layer } from 'effect'
 import { makeRushPackageManager } from './rush.impl'
@@ -8,28 +6,35 @@ import { makeYarnPackageManager } from './yarn.impl'
 import { makeNpmPackageManager } from './npm.impl'
 import { LiveFileSystem } from '../file-system/live.impl'
 import { LiveProcess } from '../process/live.impl'
+import * as fs from 'fs'
 
-const inferPackageManagerNameFromDirectoryContents = Effect.gen(function* () {
-  const { cwd } = yield* ProcessService
-  const { readDirectoryContents } = yield* FileSystemService
-  const workingDir = yield* cwd()
-  const contents = yield* readDirectoryContents(workingDir)
+const inferPackageManagerNameFromDirectoryContents = async () => {
+  const workingDir = process.cwd()
+  const contents = await fs.promises.readdir(workingDir)
   if (contents.includes('.rush')) {
-    return yield* makeRushPackageManager
+    return makeRushPackageManager
   } else if (contents.includes('pnpm-lock.yaml')) {
-    return yield* makePnpmPackageManager
+    return makePnpmPackageManager
   } else if (contents.includes('yarn.lock')) {
-    return yield* makeYarnPackageManager
+    return makeYarnPackageManager
   } else if (contents.includes('package-lock.json')) {
-    return yield* makeNpmPackageManager
+    return makeNpmPackageManager
   } else {
     // Infer npm by default
-    return yield* makeNpmPackageManager
+    return makeNpmPackageManager
   }
-})
+}
 
-export const InferredPackageManager = Layer.effect(PackageManagerService, 
-  Effect.orDie(inferPackageManagerNameFromDirectoryContents)
+export const InferredPackageManager = Layer.effect(
+  PackageManagerService,
+  Effect.orDie(
+    Effect.flatten(
+      Effect.tryPromise({
+        try: inferPackageManagerNameFromDirectoryContents,
+        catch: (reason) => reason as Error,
+      })
+    )
+  )
 )
 
 export const LivePackageManager = Layer.provide(InferredPackageManager, Layer.merge(LiveFileSystem, LiveProcess))

--- a/packages/cli/test/services/package-manager/live.test.ts
+++ b/packages/cli/test/services/package-manager/live.test.ts
@@ -1,4 +1,4 @@
-import { fake } from 'sinon'
+import { fake, replace, restore } from 'sinon'
 import { Effect, Layer, pipe } from 'effect'
 import { expect } from '../../expect'
 import { makeTestFileSystem } from '../file-system/test.impl'
@@ -6,12 +6,14 @@ import { makeTestProcess } from '../process/test.impl'
 import { PackageManagerService } from '../../../src/services/package-manager'
 import { InferredPackageManager } from '../../../src/services/package-manager/live.impl'
 import { guardError } from '../../../src/common/errors'
+import * as fs from 'fs'
 
 describe('PackageManager - Live Implementation (with inference)', () => {
   const TestProcess = makeTestProcess()
 
   afterEach(() => {
     TestProcess.reset()
+    restore()
   })
 
   const effect = Effect.gen(function* () {
@@ -25,7 +27,8 @@ describe('PackageManager - Live Implementation (with inference)', () => {
   )
 
   it('infers Rush when a `.rush` folder is present', async () => {
-    const TestFileSystem = makeTestFileSystem({ readDirectoryContents: fake.returns(['.rush']) })
+    replace(fs.promises, 'readdir', fake.resolves(['.rush']))
+    const TestFileSystem = makeTestFileSystem()
     const testLayer = Layer.merge(TestFileSystem.layer, TestProcess.layer)
     await Effect.runPromise(
       pipe(
@@ -38,7 +41,8 @@ describe('PackageManager - Live Implementation (with inference)', () => {
   })
 
   it('infers pnpm when a `pnpm-lock.yaml` file is present', async () => {
-    const TestFileSystem = makeTestFileSystem({ readDirectoryContents: fake.returns(['pnpm-lock.yaml']) })
+    replace(fs.promises, 'readdir', fake.resolves(['pnpm-lock.yaml']))
+    const TestFileSystem = makeTestFileSystem()
     const testLayer = Layer.merge(TestFileSystem.layer, TestProcess.layer)
     await Effect.runPromise(
       pipe(
@@ -51,7 +55,8 @@ describe('PackageManager - Live Implementation (with inference)', () => {
   })
 
   it('infers npm when a `package-lock.json` file is present', async () => {
-    const TestFileSystem = makeTestFileSystem({ readDirectoryContents: fake.returns(['package-lock.json']) })
+    replace(fs.promises, 'readdir', fake.resolves(['package-lock.json']))
+    const TestFileSystem = makeTestFileSystem()
     const testLayer = Layer.merge(TestFileSystem.layer, TestProcess.layer)
     await Effect.runPromise(
       pipe(
@@ -64,7 +69,8 @@ describe('PackageManager - Live Implementation (with inference)', () => {
   })
 
   it('infers yarn when a `yarn.lock` file is present', async () => {
-    const TestFileSystem = makeTestFileSystem({ readDirectoryContents: fake.returns(['yarn.lock']) })
+    replace(fs.promises, 'readdir', fake.resolves(['yarn.lock']))
+    const TestFileSystem = makeTestFileSystem()
     const testLayer = Layer.merge(TestFileSystem.layer, TestProcess.layer)
     await Effect.runPromise(
       pipe(
@@ -77,7 +83,8 @@ describe('PackageManager - Live Implementation (with inference)', () => {
   })
 
   it('infers npm when no lock file is present', async () => {
-    const TestFileSystem = makeTestFileSystem({ readDirectoryContents: fake.returns([]) })
+    replace(fs.promises, 'readdir', fake.resolves([]))
+    const TestFileSystem = makeTestFileSystem()
     const testLayer = Layer.merge(TestFileSystem.layer, TestProcess.layer)
     await Effect.runPromise(
       pipe(


### PR DESCRIPTION
## Summary
- infer package manager using native promises and flatten into an effect
- adapt inference tests to stub `fs.promises.readdir`

## Testing
- `rush lint:fix`
- `rush test` *(fails: `@magek/common` cannot find module '@magek/metadata')*
- `rush build -t @magek/metadata`
- `rush build -t @magek/common`
- `rush build -t @magek/cli`
- `rushx test`

------
https://chatgpt.com/codex/tasks/task_e_689a4c3575e8832f8ae981bb25eda35f