### PR TITLE
refactor(common): remove promise utils

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,6 +1,5 @@
 export * from './groups'
 export * from './promises'
-export * from './promise_utils'
 export * from './retrier'
 export * from './instances'
 export * from './run-command'

--- a/packages/common/src/promise_utils.ts
+++ b/packages/common/src/promise_utils.ts
@@ -1,7 +1,0 @@
-export function isRejected(promiseResult: PromiseSettledResult<unknown>): promiseResult is PromiseRejectedResult {
-  return promiseResult.status === 'rejected'
-}
-
-export function isFulfilled<T>(promiseResult: PromiseSettledResult<T>): promiseResult is PromiseFulfilledResult<T> {
-  return promiseResult.status === 'fulfilled'
-}

--- a/packages/common/src/promises.ts
+++ b/packages/common/src/promises.ts
@@ -1,5 +1,3 @@
-import { isRejected } from './promise_utils'
-
 export class Promises {
   /**
    * Waits until all the passed promise-like values are settled, no matter if they were fulfilled or rejected.
@@ -25,7 +23,9 @@ export class Promises {
     const results = await Promise.allSettled(values) // Promise.allSettled never throws
 
     // Get all the failed promises
-    const failed: Array<PromiseRejectedResult> = results.filter(isRejected)
+    const failed: Array<PromiseRejectedResult> = results.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    )
 
     // Throw if we found any failed ones
     if (failed.length > 0) {


### PR DESCRIPTION
## Summary
- replace custom promise settlement helpers with direct `status` checks
- delete `promise_utils` module and associated tests

## Testing
- `rush lint:fix`
- `rush rebuild`
- `rush test`


------
https://chatgpt.com/codex/tasks/task_e_689a4eb87714832f8238732077df4775