### PR TITLE
chore(deps-dev): bump @types/node to 22.17.1

### DIFF
--- a/adapters/nedb/event-store/package.json
+++ b/adapters/nedb/event-store/package.json
@@ -45,7 +45,7 @@
     "@types/chai": "5.2.2",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.15.21",
+    "@types/node": "22.17.1",
     "@types/sinon": "17.0.4",
     "@types/sinon-chai": "4.0.0",
     "chai": "5.2.0",

--- a/adapters/nedb/read-model-store/package.json
+++ b/adapters/nedb/read-model-store/package.json
@@ -45,7 +45,7 @@
     "@types/chai": "5.2.2",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.15.21",
+    "@types/node": "22.17.1",
     "@types/sinon": "17.0.4",
     "@types/sinon-chai": "4.0.0",
     "chai": "5.2.0",

--- a/adapters/nedb/session-store/package.json
+++ b/adapters/nedb/session-store/package.json
@@ -48,7 +48,7 @@
     "@types/chai": "5.2.2",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.15.21",
+    "@types/node": "22.17.1",
     "@types/sinon": "17.0.4",
     "@types/sinon-chai": "4.0.0",
     "chai": "5.2.0",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.15.21
-        version: 22.15.21
+        specifier: 22.17.1
+        version: 22.17.1
       '@types/sinon':
         specifier: 17.0.4
         version: 17.0.4
@@ -69,7 +69,7 @@ importers:
         version: 4.0.0(chai@5.2.0)(sinon@21.0.0)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -102,8 +102,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.15.21
-        version: 22.15.21
+        specifier: 22.17.1
+        version: 22.17.1
       '@types/sinon':
         specifier: 17.0.4
         version: 17.0.4
@@ -133,7 +133,7 @@ importers:
         version: 4.0.0(chai@5.2.0)(sinon@21.0.0)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -166,8 +166,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.15.21
-        version: 22.15.21
+        specifier: 22.17.1
+        version: 22.17.1
       '@types/sinon':
         specifier: 17.0.4
         version: 17.0.4
@@ -200,7 +200,7 @@ importers:
         version: 4.0.0(chai@5.2.0)(sinon@21.0.0)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -239,7 +239,7 @@ importers:
         version: 2.1.0
       inquirer:
         specifier: 12.6.3
-        version: 12.6.3(@types/node@22.15.21)
+        version: 12.6.3(@types/node@22.17.1)
       mustache:
         specifier: 4.2.0
         version: 4.2.0
@@ -281,8 +281,8 @@ importers:
         specifier: 4.2.6
         version: 4.2.6
       '@types/node':
-        specifier: 22.15.21
-        version: 22.15.21
+        specifier: 22.17.1
+        version: 22.17.1
       '@types/rewire':
         specifier: 2.5.28
         version: 2.5.28
@@ -324,7 +324,7 @@ importers:
         version: 4.0.0(chai@5.2.0)(sinon@21.0.0)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
       ts-patch:
         specifier: 3.3.0
         version: 3.3.0
@@ -366,8 +366,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.15.21
-        version: 22.15.21
+        specifier: 22.17.1
+        version: 22.17.1
       '@types/rewire':
         specifier: 2.5.28
         version: 2.5.28
@@ -412,7 +412,7 @@ importers:
         version: 4.0.0(chai@5.2.0)(sinon@21.0.0)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -514,8 +514,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.15.21
-        version: 22.15.21
+        specifier: 22.17.1
+        version: 22.17.1
       '@types/sinon':
         specifier: 17.0.4
         version: 17.0.4
@@ -542,7 +542,7 @@ importers:
         version: 11.7.1
       mock-jwks:
         specifier: 3.3.5
-        version: 3.3.5(@types/node@22.15.21)(typescript@5.8.3)
+        version: 3.3.5(@types/node@22.17.1)(typescript@5.8.3)
       nyc:
         specifier: 17.1.0
         version: 17.1.0
@@ -557,7 +557,7 @@ importers:
         version: 4.0.0(chai@5.2.0)(sinon@21.0.0)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
       ts-patch:
         specifier: 3.3.0
         version: 3.3.0
@@ -593,8 +593,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.15.21
-        version: 22.15.21
+        specifier: 22.17.1
+        version: 22.17.1
       '@types/prompts':
         specifier: 2.4.9
         version: 2.4.9
@@ -615,10 +615,10 @@ importers:
         version: 21.0.0
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
       tsup:
         specifier: 8.0.0
-        version: 8.0.0(ts-node@10.9.1(@types/node@22.15.21)(typescript@5.8.3))(typescript@5.8.3)
+        version: 8.0.0(ts-node@10.9.1(@types/node@22.17.1)(typescript@5.8.3))(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -645,8 +645,8 @@ importers:
         specifier: 8.0.2
         version: 8.0.2
       '@types/node':
-        specifier: 22.15.21
-        version: 22.15.21
+        specifier: 22.17.1
+        version: 22.17.1
       chai-as-promised:
         specifier: 8.0.1
         version: 8.0.1(chai@5.2.0)
@@ -658,7 +658,7 @@ importers:
         version: 21.0.0
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
       ts-patch:
         specifier: 3.3.0
         version: 3.3.0
@@ -709,8 +709,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.15.21
-        version: 22.15.21
+        specifier: 22.17.1
+        version: 22.17.1
       '@types/sinon':
         specifier: 17.0.4
         version: 17.0.4
@@ -740,7 +740,7 @@ importers:
         version: 4.0.0(chai@5.2.0)(sinon@21.0.0)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -791,8 +791,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.15.21
-        version: 22.15.21
+        specifier: 22.17.1
+        version: 22.17.1
       '@types/node-schedule':
         specifier: 2.1.7
         version: 2.1.7
@@ -825,7 +825,7 @@ importers:
         version: 4.0.0(chai@5.2.0)(sinon@21.0.0)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+        version: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -1883,7 +1883,7 @@ packages:
   '@types/node-schedule@2.1.7':
     resolution: {integrity: sha512-G7Z3R9H7r3TowoH6D2pkzUHPhcJrDF4Jz1JOQ80AX0K2DWTHoN9VC94XzFAPNMdbW9TBzMZ3LjpFi7RYdbxtXA==}
 
-  '@types/node@22.15.21':
+  '@types/node@22.17.1':
     resolution: {integrity: sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==}
 
   '@types/prompts@2.4.9':
@@ -5066,27 +5066,27 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/checkbox@4.2.0(@types/node@22.15.21)':
+  '@inquirer/checkbox@4.2.0(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/confirm@5.1.14(@types/node@22.15.21)':
+  '@inquirer/confirm@5.1.14(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/core@10.1.15(@types/node@22.15.21)':
+  '@inquirer/core@10.1.15(@types/node@22.17.1)':
     dependencies:
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -5094,93 +5094,93 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/editor@4.2.15(@types/node@22.15.21)':
+  '@inquirer/editor@4.2.15(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
       external-editor: 3.1.0
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/expand@4.0.17(@types/node@22.15.21)':
+  '@inquirer/expand@4.0.17(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
   '@inquirer/figures@1.0.13': {}
 
-  '@inquirer/input@4.2.1(@types/node@22.15.21)':
+  '@inquirer/input@4.2.1(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/number@3.0.17(@types/node@22.15.21)':
+  '@inquirer/number@3.0.17(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/password@4.0.17(@types/node@22.15.21)':
+  '@inquirer/password@4.0.17(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
       ansi-escapes: 4.3.2
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/prompts@7.8.0(@types/node@22.15.21)':
+  '@inquirer/prompts@7.8.0(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/checkbox': 4.2.0(@types/node@22.15.21)
-      '@inquirer/confirm': 5.1.14(@types/node@22.15.21)
-      '@inquirer/editor': 4.2.15(@types/node@22.15.21)
-      '@inquirer/expand': 4.0.17(@types/node@22.15.21)
-      '@inquirer/input': 4.2.1(@types/node@22.15.21)
-      '@inquirer/number': 3.0.17(@types/node@22.15.21)
-      '@inquirer/password': 4.0.17(@types/node@22.15.21)
-      '@inquirer/rawlist': 4.1.5(@types/node@22.15.21)
-      '@inquirer/search': 3.1.0(@types/node@22.15.21)
-      '@inquirer/select': 4.3.1(@types/node@22.15.21)
+      '@inquirer/checkbox': 4.2.0(@types/node@22.17.1)
+      '@inquirer/confirm': 5.1.14(@types/node@22.17.1)
+      '@inquirer/editor': 4.2.15(@types/node@22.17.1)
+      '@inquirer/expand': 4.0.17(@types/node@22.17.1)
+      '@inquirer/input': 4.2.1(@types/node@22.17.1)
+      '@inquirer/number': 3.0.17(@types/node@22.17.1)
+      '@inquirer/password': 4.0.17(@types/node@22.17.1)
+      '@inquirer/rawlist': 4.1.5(@types/node@22.17.1)
+      '@inquirer/search': 3.1.0(@types/node@22.17.1)
+      '@inquirer/select': 4.3.1(@types/node@22.17.1)
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/rawlist@4.1.5(@types/node@22.15.21)':
+  '@inquirer/rawlist@4.1.5(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/search@3.1.0(@types/node@22.15.21)':
+  '@inquirer/search@3.1.0(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/select@4.3.1(@types/node@22.15.21)':
+  '@inquirer/select@4.3.1(@types/node@22.17.1)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@inquirer/type@3.0.8(@types/node@22.15.21)':
+  '@inquirer/type@3.0.8(@types/node@22.17.1)':
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -5524,7 +5524,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
   '@types/chai-as-promised@8.0.2':
     dependencies:
@@ -5536,7 +5536,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
   '@types/cookie@0.6.0': {}
 
@@ -5548,7 +5548,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -5563,7 +5563,7 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
   '@types/http-errors@2.0.5': {}
 
@@ -5575,12 +5575,12 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
   '@types/lodash@4.17.20': {}
 
@@ -5594,15 +5594,15 @@ snapshots:
 
   '@types/node-schedule@2.1.7':
     dependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
-  '@types/node@22.15.21':
+  '@types/node@22.17.1':
     dependencies:
       undici-types: 6.21.0
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
       kleur: 3.0.3
 
   '@types/qs@6.14.0': {}
@@ -5614,12 +5614,12 @@ snapshots:
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
   '@types/serve-static@1.15.8':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
       '@types/send': 0.17.5
 
   '@types/sinon-chai@4.0.0':
@@ -6550,7 +6550,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@types/lodash': 4.17.20
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
       '@types/sinon': 17.0.4
       lodash: 4.17.21
       mock-stdin: 1.0.0
@@ -6950,17 +6950,17 @@ snapshots:
 
   ini@4.1.3: {}
 
-  inquirer@12.6.3(@types/node@22.15.21):
+  inquirer@12.6.3(@types/node@22.17.1):
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@22.15.21)
-      '@inquirer/prompts': 7.8.0(@types/node@22.15.21)
-      '@inquirer/type': 3.0.8(@types/node@22.15.21)
+      '@inquirer/core': 10.1.15(@types/node@22.17.1)
+      '@inquirer/prompts': 7.8.0(@types/node@22.17.1)
+      '@inquirer/type': 3.0.8(@types/node@22.17.1)
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
 
   internal-slot@1.1.0:
     dependencies:
@@ -7478,11 +7478,11 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
-  mock-jwks@3.3.5(@types/node@22.15.21)(typescript@5.8.3):
+  mock-jwks@3.3.5(@types/node@22.17.1)(typescript@5.8.3):
     dependencies:
       base64-url: 2.3.3
       jsonwebtoken: 9.0.2
-      msw: 2.10.4(@types/node@22.15.21)(typescript@5.8.3)
+      msw: 2.10.4(@types/node@22.17.1)(typescript@5.8.3)
       node-forge: 1.3.1
       node-rsa: 1.1.1
     transitivePeerDependencies:
@@ -7509,12 +7509,12 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
-  msw@2.10.4(@types/node@22.15.21)(typescript@5.8.3):
+  msw@2.10.4(@types/node@22.17.1)(typescript@5.8.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.14(@types/node@22.15.21)
+      '@inquirer/confirm': 5.1.14(@types/node@22.17.1)
       '@mswjs/interceptors': 0.39.5
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
@@ -7827,12 +7827,12 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@4.0.2(ts-node@10.9.1(@types/node@22.15.21)(typescript@5.8.3)):
+  postcss-load-config@4.0.2(ts-node@10.9.1(@types/node@22.17.1)(typescript@5.8.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.0
     optionalDependencies:
-      ts-node: 10.9.1(@types/node@22.15.21)(typescript@5.8.3)
+      ts-node: 10.9.1(@types/node@22.17.1)(typescript@5.8.3)
 
   prelude-ls@1.2.1: {}
 
@@ -8375,14 +8375,14 @@ snapshots:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
 
-  ts-node@10.9.1(@types/node@22.15.21)(typescript@5.8.3):
+  ts-node@10.9.1(@types/node@22.17.1)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.15.21
+      '@types/node': 22.17.1
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -8413,7 +8413,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.0.0(ts-node@10.9.1(@types/node@22.15.21)(typescript@5.8.3))(typescript@5.8.3):
+  tsup@8.0.0(ts-node@10.9.1(@types/node@22.17.1)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.19.12)
       cac: 6.7.14
@@ -8423,7 +8423,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(ts-node@10.9.1(@types/node@22.15.21)(typescript@5.8.3))
+      postcss-load-config: 4.0.2(ts-node@10.9.1(@types/node@22.17.1)(typescript@5.8.3))
       resolve-from: 5.0.0
       rollup: 4.46.2
       source-map: 0.8.0-beta.0

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
     "@types/inflected": "2.1.3",
     "@types/mocha": "10.0.10",
     "@types/mustache": "4.2.6",
-    "@types/node": "22.15.21",
+    "@types/node": "22.17.1",
     "@types/rewire": "2.5.28",
     "@types/sinon": "17.0.4",
     "@types/sinon-chai": "4.0.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -47,7 +47,7 @@
     "@types/chai": "5.2.2",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.15.21",
+    "@types/node": "22.17.1",
     "@types/rewire": "2.5.28",
     "@types/sinon": "17.0.4",
     "@types/sinon-chai": "4.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,7 +66,7 @@
     "@types/inflected": "2.1.3",
     "@types/jsonwebtoken": "9.0.10",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.15.21",
+    "@types/node": "22.17.1",
     "@types/sinon": "17.0.4",
     "@types/sinon-chai": "4.0.0",
     "@types/validator": "13.15.2",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@magek/eslint-config": "workspace:^0.0.1",
-    "@types/node": "22.15.21",
+    "@types/node": "22.17.1",
     "@types/prompts": "2.4.9",
     "@types/chai": "5.2.2",
     "@types/mocha": "10.0.10",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@magek/eslint-config": "workspace:^0.0.1",
-    "@types/node": "22.15.21",
+    "@types/node": "22.17.1",
     "ts-node": "10.9.1",
     "ts-patch": "3.3.0",
     "typescript": "5.8.3",

--- a/packages/server-infrastructure/package.json
+++ b/packages/server-infrastructure/package.json
@@ -51,7 +51,7 @@
     "@types/chai": "5.2.2",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.15.21",
+    "@types/node": "22.17.1",
     "@types/node-schedule": "2.1.7",
     "@types/sinon": "17.0.4",
     "@types/sinon-chai": "4.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -50,7 +50,7 @@
     "@types/chai": "5.2.2",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.15.21",
+    "@types/node": "22.17.1",
     "@types/sinon": "17.0.4",
     "@types/sinon-chai": "4.0.0",
     "chai": "5.2.0",


### PR DESCRIPTION
## Summary
- bump @types/node to 22.17.1 across packages

## Testing
- `rush lint:fix`
- `rush test`


------
https://chatgpt.com/codex/tasks/task_e_689a6f69e0b8832fb6c78022a85ff5fa