### PR TITLE
fix(rush): remove mainProject to fix change file verification

### DIFF
--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -102,7 +102,6 @@
   {
     "definitionName": "lockStepVersion",
     "policyName": "magek",
-    "mainProject": "@magek/core",
     "version": "0.0.4",
     "nextBump": "patch"
   }


### PR DESCRIPTION
## Summary

- Removes the `mainProject` field from the lockstep version policy in `version-policies.json`
- Fixes `rush change --verify` requiring change files for `@magek/core` when only other packages are modified
- Each package will now maintain its own CHANGELOG.md while still using lockstep versioning

## Test plan

- [x] Verified `rush change --verify` passes after the change
- [x] Pre-commit hook validation passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)