### PR TITLE
feat: add in-memory adapters and custom adapter documentation

### DIFF
--- a/adapters/memory/event-store/.mocharc.yml
+++ b/adapters/memory/event-store/.mocharc.yml
@@ -1,0 +1,11 @@
+diff: true
+require: tsx/cjs
+extension:
+  - ts
+package: './package.json'
+recursive: true
+reporter: 'spec'
+timeout: 5000
+full-trace: true
+bail: true
+color: true

--- a/adapters/memory/event-store/eslint.config.mjs
+++ b/adapters/memory/event-store/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.eslint.json'
+      }
+    }
+  }
+]

--- a/adapters/memory/event-store/package.json
+++ b/adapters/memory/event-store/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@magek/adapter-event-store-memory",
+  "version": "0.0.6",
+  "description": "In-memory event store adapter for the Magek framework",
+  "keywords": [
+    "event-store",
+    "memory",
+    "in-memory"
+  ],
+  "author": "Boosterin Labs SLU",
+  "homepage": "https://magek.ai",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theam/magek.git"
+  },
+  "engines": {
+    "node": ">=22.0.0 <23.0.0"
+  },
+  "dependencies": {
+    "@magek/common": "workspace:^0.0.6",
+    "tslib": "2.8.1"
+  },
+  "scripts": {
+    "format": "prettier --write --ext '.js,.ts' **/*.ts **/*/*.ts",
+    "lint:check": "eslint \"**/*.ts\"",
+    "lint:fix": "eslint --quiet --fix \"**/*.ts\"",
+    "build": "tsc -b tsconfig.json",
+    "clean": "rimraf ./dist tsconfig.tsbuildinfo",
+    "prepack": "tsc -b tsconfig.json",
+    "test": "tsc --noEmit -p tsconfig.test.json && c8 mocha --forbid-only \"test/**/*.test.ts\""
+  },
+  "bugs": {
+    "url": "https://github.com/theam/magek/issues"
+  },
+  "devDependencies": {
+    "@magek/eslint-config": "workspace:^0.0.6",
+    "@types/chai": "5.2.3",
+    "@types/chai-as-promised": "8.0.2",
+    "@types/mocha": "10.0.10",
+    "@types/node": "22.19.7",
+    "@types/sinon": "21.0.0",
+    "@types/sinon-chai": "4.0.0",
+    "chai": "6.2.2",
+    "chai-as-promised": "8.0.2",
+    "@faker-js/faker": "10.2.0",
+    "mocha": "11.7.5",
+    "c8": "^10.1.3",
+    "rimraf": "6.1.2",
+    "sinon": "21.0.1",
+    "sinon-chai": "4.0.1",
+    "tsx": "^4.19.2",
+    "typescript": "5.9.3"
+  }
+}

--- a/adapters/memory/event-store/package.json
+++ b/adapters/memory/event-store/package.json
@@ -45,7 +45,7 @@
     "@types/chai": "5.2.3",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.19.7",
+    "@types/node": "22.19.8",
     "@types/sinon": "21.0.0",
     "@types/sinon-chai": "4.0.0",
     "chai": "6.2.2",

--- a/adapters/memory/event-store/package.json
+++ b/adapters/memory/event-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magek/adapter-event-store-memory",
-  "version": "0.0.6",
+  "version": "0.0.10",
   "description": "In-memory event store adapter for the Magek framework",
   "keywords": [
     "event-store",
@@ -25,7 +25,7 @@
     "node": ">=22.0.0 <23.0.0"
   },
   "dependencies": {
-    "@magek/common": "workspace:^0.0.6",
+    "@magek/common": "workspace:^0.0.10",
     "tslib": "2.8.1"
   },
   "scripts": {
@@ -41,7 +41,7 @@
     "url": "https://github.com/theam/magek/issues"
   },
   "devDependencies": {
-    "@magek/eslint-config": "workspace:^0.0.6",
+    "@magek/eslint-config": "workspace:^0.0.10",
     "@types/chai": "5.2.3",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",

--- a/adapters/memory/event-store/src/index.ts
+++ b/adapters/memory/event-store/src/index.ts
@@ -1,0 +1,412 @@
+import {
+  UUID,
+  UserApp,
+  MagekConfig,
+  NonPersistedEventEnvelope,
+  NonPersistedEntitySnapshotEnvelope,
+  EventSearchParameters,
+  EventDeleteParameters,
+  EventEnvelopeFromDatabase,
+  SnapshotDeleteParameters,
+  EntitySnapshotEnvelopeFromDatabase,
+  EventStoreAdapter,
+  EventEnvelope,
+  EntitySnapshotEnvelope,
+  EventSearchResponse,
+  PaginatedEntitiesIdsResult,
+  getLogger,
+  unique,
+  retryIfError,
+  OptimisticConcurrencyUnexpectedVersionError,
+  EventParametersFilterByEntity,
+  EventParametersFilterByType,
+} from '@magek/common'
+import { MemoryEventRegistry, QueryFilter } from './memory-event-registry'
+import * as path from 'path'
+
+// Pre-built Memory Event Store Adapter instance
+const eventRegistry = new MemoryEventRegistry()
+
+const originOfTime = new Date(0).toISOString()
+
+function notImplemented(): any {
+  throw new Error('Not implemented for Memory adapter')
+}
+
+// Function to get userApp from config or load it from standard location
+function getUserApp(config: MagekConfig): UserApp {
+  // Check if userApp is attached to config
+  if ((config as any).userApp) {
+    return (config as any).userApp
+  }
+
+  // Fallback to loading from standard location
+  try {
+    return require(path.join(process.cwd(), 'dist', 'index.js'))
+  } catch (error) {
+    throw new Error('Could not load userApp from config or standard location')
+  }
+}
+
+export function rawEventsToEnvelopes(rawEvents: Array<unknown>): Array<EventEnvelope> {
+  return rawEvents.map((event) => event as EventEnvelope)
+}
+
+async function readEntityEventsSince(
+  registry: MemoryEventRegistry,
+  config: MagekConfig,
+  entityTypeName: string,
+  entityID: UUID,
+  since?: string
+): Promise<Array<EventEnvelope>> {
+  const logger = getLogger(config, 'memory-events-adapter#readEntityEventsSince')
+  const fromTime = since ? since : originOfTime
+
+  const query: QueryFilter = {
+    entityID: entityID,
+    entityTypeName: entityTypeName,
+    kind: 'event',
+    createdAt: {
+      $gt: fromTime,
+    },
+    deletedAt: { $exists: false },
+  }
+  const result = await registry.query(query)
+
+  logger.debug(`Loaded events for entity ${entityTypeName} with ID ${entityID} with result:`, result)
+  return result as Array<EventEnvelope>
+}
+
+async function readEntityLatestSnapshot(
+  registry: MemoryEventRegistry,
+  config: MagekConfig,
+  entityTypeName: string,
+  entityID: UUID
+): Promise<EntitySnapshotEnvelope | undefined> {
+  const logger = getLogger(config, 'memory-events-adapter#readEntityLatestSnapshot')
+  const query: QueryFilter = {
+    entityID: entityID,
+    entityTypeName: entityTypeName,
+    kind: 'snapshot',
+  }
+
+  const snapshot = await registry.queryLatestSnapshot(query)
+
+  if (snapshot) {
+    logger.debug(`Snapshot found for entity ${entityTypeName} with ID ${entityID}:`, snapshot)
+    return snapshot as EntitySnapshotEnvelope
+  } else {
+    logger.debug(`No snapshot found for entity ${entityTypeName} with ID ${entityID}.`)
+    return undefined
+  }
+}
+
+async function storeEvents(
+  userApp: UserApp,
+  registry: MemoryEventRegistry,
+  nonPersistedEventEnvelopes: Array<NonPersistedEventEnvelope>,
+  config: MagekConfig
+): Promise<Array<EventEnvelope>> {
+  const logger = getLogger(config, 'memory-events-adapter#storeEvents')
+  logger.debug('Storing the following event envelopes:', nonPersistedEventEnvelopes)
+  const persistedEventEnvelopes: Array<EventEnvelope> = []
+  for (const nonPersistedEventEnvelope of nonPersistedEventEnvelopes) {
+    const persistableEventEnvelope: EventEnvelope = {
+      ...nonPersistedEventEnvelope,
+      createdAt: new Date().toISOString(),
+    }
+    await retryIfError(
+      async () => await registry.store(persistableEventEnvelope),
+      OptimisticConcurrencyUnexpectedVersionError
+    )
+    persistedEventEnvelopes.push(persistableEventEnvelope)
+  }
+  logger.debug('EventEnvelopes stored: ', persistedEventEnvelopes)
+
+  await userApp.eventDispatcher(persistedEventEnvelopes)
+  return persistedEventEnvelopes
+}
+
+async function storeSnapshot(
+  registry: MemoryEventRegistry,
+  snapshotEnvelope: NonPersistedEntitySnapshotEnvelope,
+  config: MagekConfig
+): Promise<EntitySnapshotEnvelope> {
+  const logger = getLogger(config, 'memory-events-adapter#storeSnapshot')
+  logger.debug('Storing the following snapshot envelope:', snapshotEnvelope)
+  const persistableEntitySnapshot: EntitySnapshotEnvelope = {
+    ...snapshotEnvelope,
+    createdAt: snapshotEnvelope.snapshottedEventCreatedAt,
+    persistedAt: new Date().toISOString(),
+  }
+  await retryIfError(
+    () => registry.store(persistableEntitySnapshot),
+    OptimisticConcurrencyUnexpectedVersionError
+  )
+  logger.debug('Snapshot stored')
+  return persistableEntitySnapshot
+}
+
+async function storeDispatchedEvent(registry: MemoryEventRegistry, eventEnvelope: EventEnvelope): Promise<boolean> {
+  const eventId = eventEnvelope.id || `${eventEnvelope.entityTypeName}:${eventEnvelope.entityID}:${eventEnvelope.createdAt}`
+  return registry.storeDispatched(eventId)
+}
+
+function buildFiltersForByTime(fromValue?: string, toValue?: string): { createdAt?: any } {
+  if (fromValue && toValue) {
+    return {
+      createdAt: { $gte: fromValue, $lte: toValue },
+    }
+  } else if (fromValue) {
+    return {
+      createdAt: { $gte: fromValue },
+    }
+  } else if (toValue) {
+    return {
+      createdAt: { $lte: toValue },
+    }
+  }
+  return {}
+}
+
+function buildFiltersForByFilters(
+  filters: EventParametersFilterByEntity | EventParametersFilterByType
+): QueryFilter {
+  if ('entity' in filters) {
+    if (filters.entityID) {
+      return {
+        entityTypeName: filters.entity,
+        entityID: filters.entityID,
+      }
+    }
+    return {
+      entityTypeName: filters.entity,
+    }
+  } else if ('type' in filters) {
+    return {
+      typeName: filters.type,
+    }
+  } else {
+    throw new Error('Invalid search event query. It is neither an search by "entity" nor a search by "type"')
+  }
+}
+
+function resultToEventSearchResponse(result: Array<EventEnvelope> | null): Array<EventSearchResponse> {
+  if (!result || result.length === 0) return []
+  const eventSearchResult = result.map((item) => {
+    return {
+      type: item.typeName,
+      entity: item.entityTypeName,
+      entityID: item.entityID,
+      requestID: item.requestID,
+      user: item.currentUser,
+      createdAt: item.createdAt,
+      value: item.value,
+      deletedAt: item.deletedAt,
+    } as EventSearchResponse
+  })
+  return eventSearchResult ?? []
+}
+
+async function searchEvents(
+  registry: MemoryEventRegistry,
+  config: MagekConfig,
+  parameters: EventSearchParameters
+): Promise<Array<EventSearchResponse>> {
+  const logger = getLogger(config, 'memory-events-adapter#searchEvents')
+  logger.debug('Initiating an events search. Filters: ', parameters)
+  const timeFilterQuery = buildFiltersForByTime(parameters.from, parameters.to)
+  const eventFilterQuery = buildFiltersForByFilters(parameters)
+  const filterQuery: QueryFilter = { ...eventFilterQuery, ...timeFilterQuery, kind: 'event' }
+  const result = (await registry.query(filterQuery, 'desc', parameters.limit)) as Array<EventEnvelope>
+  const eventsSearchResponses = resultToEventSearchResponse(result)
+  logger.debug('Events search result: ', eventsSearchResponses)
+  return eventsSearchResponses
+}
+
+async function searchEntitiesIds(
+  registry: MemoryEventRegistry,
+  config: MagekConfig,
+  limit: number,
+  afterCursor: Record<string, string> | undefined,
+  entityTypeName: string
+): Promise<PaginatedEntitiesIdsResult> {
+  const logger = getLogger(config, 'memory-events-adapter#searchEntitiesIds')
+  logger.debug(
+    `Initiating a paginated events search. limit: ${limit}, afterCursor: ${JSON.stringify(
+      afterCursor
+    )}, entityTypeName: ${entityTypeName}`
+  )
+  const filterQuery: QueryFilter = {
+    kind: 'event',
+    entityTypeName: entityTypeName,
+    deletedAt: { $exists: false },
+  }
+
+  const result = (await registry.query(filterQuery, 'desc')) as Array<EventEnvelope>
+
+  const entitiesIds = result ? result?.map((v) => v.entityID) : []
+  const uniqueResult = unique(entitiesIds)
+  const skipId = afterCursor?.id ? parseInt(afterCursor?.id) : 0
+  const paginated = uniqueResult.slice(skipId, skipId + limit)
+  const paginatedResult = paginated.map((v) => ({ entityID: v }))
+  logger.debug('Unique events search result', paginatedResult)
+  return {
+    items: paginatedResult,
+    count: paginatedResult?.length ?? 0,
+    cursor: { id: ((limit ? limit : 1) + skipId).toString() },
+  } as PaginatedEntitiesIdsResult
+}
+
+type DatabaseEventEnvelopeWithId = EventEnvelope & { id: string }
+type DatabaseEntitySnapshotEnvelopeWithId = EntitySnapshotEnvelope & { id: string }
+
+async function findDeletableEvent(
+  registry: MemoryEventRegistry,
+  config: MagekConfig,
+  parameters: EventDeleteParameters
+): Promise<Array<EventEnvelopeFromDatabase>> {
+  const logger = getLogger(config, 'memory-events-adapter#findDeletableEvent')
+  const stringifyParameters = JSON.stringify(parameters)
+  logger.debug(`Initiating a deletable event search for ${stringifyParameters}`)
+
+  const filter: QueryFilter = {
+    entityTypeName: parameters.entityTypeName,
+    entityID: parameters.entityID,
+    createdAt: parameters.createdAt,
+    kind: 'event',
+    deletedAt: { $exists: false },
+  }
+  const events = (await registry.query(filter)) as Array<DatabaseEventEnvelopeWithId>
+  const result = events.map((event) => {
+    return {
+      ...event,
+      id: event.id,
+    }
+  }) as Array<EventEnvelopeFromDatabase>
+  logger.debug(`Finished deletable event search for ${stringifyParameters}`)
+  return result
+}
+
+async function findDeletableSnapshot(
+  registry: MemoryEventRegistry,
+  config: MagekConfig,
+  parameters: SnapshotDeleteParameters
+): Promise<Array<EntitySnapshotEnvelopeFromDatabase>> {
+  const logger = getLogger(config, 'memory-events-adapter#findDeletableSnapshot')
+  const stringifyParameters = JSON.stringify(parameters)
+  logger.debug(`Initiating a deletable snapshot search for ${stringifyParameters}`)
+
+  const filter: QueryFilter = {
+    entityTypeName: parameters.entityTypeName,
+    entityID: parameters.entityID,
+    createdAt: parameters.createdAt,
+    kind: 'snapshot',
+    deletedAt: { $exists: false },
+  }
+  const snapshots = (await registry.query(filter)) as Array<DatabaseEntitySnapshotEnvelopeWithId>
+  const result: Array<EntitySnapshotEnvelopeFromDatabase> = snapshots.map((snapshot) => {
+    return {
+      ...snapshot,
+      id: snapshot.id,
+    }
+  })
+  logger.debug(`Finished deletable snapshot search for ${stringifyParameters}`)
+  return result
+}
+
+function buildNewEvent(existingEvent: EventEnvelopeFromDatabase): EventEnvelope {
+  return {
+    ...existingEvent,
+    deletedAt: new Date().toISOString(),
+    value: {},
+  }
+}
+
+async function deleteEvent(
+  registry: MemoryEventRegistry,
+  config: MagekConfig,
+  events: Array<EventEnvelopeFromDatabase>
+): Promise<void> {
+  const logger = getLogger(config, 'memory-events-adapter#deleteEvent')
+  const stringifyParameters = JSON.stringify(events)
+  logger.debug(`Initiating an event delete for ${stringifyParameters}`)
+
+  if (!events || events.length === 0) {
+    logger.warn('Could not find events to delete')
+    return
+  }
+  for (const event of events) {
+    const newEvent = buildNewEvent(event)
+    await registry.replaceOrDeleteItem(event.id, newEvent)
+  }
+  logger.debug(`Finished event delete for ${stringifyParameters}`)
+}
+
+async function deleteSnapshot(
+  registry: MemoryEventRegistry,
+  config: MagekConfig,
+  snapshots: Array<EntitySnapshotEnvelopeFromDatabase>
+): Promise<void> {
+  const logger = getLogger(config, 'memory-events-adapter#deleteSnapshot')
+  const stringifyParameters = JSON.stringify(snapshots)
+  logger.debug(`Initiating a snapshot delete for ${stringifyParameters}`)
+
+  if (!snapshots || snapshots.length === 0) {
+    logger.warn('Could not find snapshot to delete')
+    return
+  }
+  for (const snapshot of snapshots) {
+    await registry.replaceOrDeleteItem(snapshot.id)
+  }
+  logger.debug(`Finished snapshot delete for ${stringifyParameters}`)
+}
+
+export const eventStore: EventStoreAdapter = {
+  rawToEnvelopes: rawEventsToEnvelopes,
+  rawStreamToEnvelopes: notImplemented,
+  dedupEventStream: notImplemented,
+  produce: notImplemented,
+  forEntitySince: (config: MagekConfig, entityTypeName: string, entityID: UUID, since?: string) =>
+    readEntityEventsSince(eventRegistry, config, entityTypeName, entityID, since),
+  latestEntitySnapshot: (config: MagekConfig, entityTypeName: string, entityID: UUID) =>
+    readEntityLatestSnapshot(eventRegistry, config, entityTypeName, entityID),
+  store: (eventEnvelopes: Array<NonPersistedEventEnvelope>, config: MagekConfig) => {
+    const userApp = getUserApp(config)
+    return storeEvents(userApp, eventRegistry, eventEnvelopes, config)
+  },
+  storeSnapshot: (snapshotEnvelope: NonPersistedEntitySnapshotEnvelope, config: MagekConfig) =>
+    storeSnapshot(eventRegistry, snapshotEnvelope, config),
+  search: (config: MagekConfig, parameters: EventSearchParameters) =>
+    searchEvents(eventRegistry, config, parameters),
+  searchEntitiesIDs: (
+    config: MagekConfig,
+    limit: number,
+    afterCursor: Record<string, string> | undefined,
+    entityTypeName: string
+  ) => searchEntitiesIds(eventRegistry, config, limit, afterCursor, entityTypeName),
+  storeDispatched: (eventEnvelope: EventEnvelope, config: MagekConfig) =>
+    storeDispatchedEvent(eventRegistry, eventEnvelope),
+  findDeletableEvent: (config: MagekConfig, parameters: EventDeleteParameters) =>
+    findDeletableEvent(eventRegistry, config, parameters),
+  findDeletableSnapshot: (config: MagekConfig, parameters: SnapshotDeleteParameters) =>
+    findDeletableSnapshot(eventRegistry, config, parameters),
+  deleteEvent: (config: MagekConfig, events: Array<EventEnvelopeFromDatabase>) =>
+    deleteEvent(eventRegistry, config, events),
+  deleteSnapshot: (config: MagekConfig, snapshots: Array<EntitySnapshotEnvelopeFromDatabase>) =>
+    deleteSnapshot(eventRegistry, config, snapshots),
+  healthCheck: {
+    isUp: async () => true,
+    details: async () => {
+      return {
+        type: 'memory',
+        eventsCount: eventRegistry.getEventsCount(),
+        snapshotsCount: eventRegistry.getSnapshotsCount(),
+      }
+    },
+    urls: async () => ['memory://in-memory-event-store'],
+  },
+}
+
+// Export components for testing
+export { MemoryEventRegistry } from './memory-event-registry'

--- a/adapters/memory/event-store/src/index.ts
+++ b/adapters/memory/event-store/src/index.ts
@@ -1,6 +1,5 @@
 import {
   UUID,
-  UserApp,
   MagekConfig,
   NonPersistedEventEnvelope,
   NonPersistedEntitySnapshotEnvelope,
@@ -22,30 +21,17 @@ import {
   EventParametersFilterByType,
 } from '@magek/common'
 import { MemoryEventRegistry, QueryFilter } from './memory-event-registry'
-import * as path from 'path'
 
 // Pre-built Memory Event Store Adapter instance
 const eventRegistry = new MemoryEventRegistry()
 
 const originOfTime = new Date(0).toISOString()
 
+// In-memory cursor for async event processing
+let processingCursor: string = originOfTime
+
 function notImplemented(): any {
   throw new Error('Not implemented for Memory adapter')
-}
-
-// Function to get userApp from config or load it from standard location
-function getUserApp(config: MagekConfig): UserApp {
-  // Check if userApp is attached to config
-  if ((config as any).userApp) {
-    return (config as any).userApp
-  }
-
-  // Fallback to loading from standard location
-  try {
-    return require(path.join(process.cwd(), 'dist', 'index.js'))
-  } catch (error) {
-    throw new Error('Could not load userApp from config or standard location')
-  }
 }
 
 export function rawEventsToEnvelopes(rawEvents: Array<unknown>): Array<EventEnvelope> {
@@ -102,7 +88,6 @@ async function readEntityLatestSnapshot(
 }
 
 async function storeEvents(
-  userApp: UserApp,
   registry: MemoryEventRegistry,
   nonPersistedEventEnvelopes: Array<NonPersistedEventEnvelope>,
   config: MagekConfig
@@ -123,7 +108,6 @@ async function storeEvents(
   }
   logger.debug('EventEnvelopes stored: ', persistedEventEnvelopes)
 
-  await userApp.eventDispatcher(persistedEventEnvelopes)
   return persistedEventEnvelopes
 }
 
@@ -150,6 +134,49 @@ async function storeSnapshot(
 async function storeDispatchedEvent(registry: MemoryEventRegistry, eventEnvelope: EventEnvelope): Promise<boolean> {
   const eventId = eventEnvelope.id || `${eventEnvelope.entityTypeName}:${eventEnvelope.entityID}:${eventEnvelope.createdAt}`
   return registry.storeDispatched(eventId)
+}
+
+async function fetchUnprocessedEvents(
+  registry: MemoryEventRegistry,
+  config: MagekConfig
+): Promise<Array<EventEnvelope>> {
+  const logger = getLogger(config, 'memory-events-adapter#fetchUnprocessedEvents')
+  const batchSize = config.eventProcessingBatchSize
+
+  const query: QueryFilter = {
+    kind: 'event',
+    deletedAt: { $exists: false },
+    processedAt: { $exists: false },
+    createdAt: { $gt: processingCursor },
+  }
+
+  logger.debug(`Fetching events after cursor ${processingCursor} (batch size: ${batchSize})`)
+  const result = await registry.query(query, 'asc', batchSize)
+
+  logger.debug(`Fetched ${result.length} unprocessed events`)
+  return result as Array<EventEnvelope>
+}
+
+async function markEventProcessed(
+  registry: MemoryEventRegistry,
+  config: MagekConfig,
+  eventId: UUID
+): Promise<void> {
+  const logger = getLogger(config, 'memory-events-adapter#markEventProcessed')
+  const processedAt = new Date().toISOString()
+
+  const events = await registry.query({ _id: eventId.toString(), kind: 'event' })
+  if (events.length === 0) {
+    logger.warn(`Event ${eventId} not found, cannot mark as processed`)
+    return
+  }
+  const event = events[0] as EventEnvelope
+
+  logger.debug(`Marking event ${eventId} as processed at ${processedAt}`)
+  await registry.markProcessed(eventId.toString(), processedAt)
+
+  processingCursor = event.createdAt
+  logger.debug(`Cursor advanced to ${processingCursor}`)
 }
 
 function buildFiltersForByTime(fromValue?: string, toValue?: string): { createdAt?: any } {
@@ -371,10 +398,8 @@ export const eventStore: EventStoreAdapter = {
     readEntityEventsSince(eventRegistry, config, entityTypeName, entityID, since),
   latestEntitySnapshot: (config: MagekConfig, entityTypeName: string, entityID: UUID) =>
     readEntityLatestSnapshot(eventRegistry, config, entityTypeName, entityID),
-  store: (eventEnvelopes: Array<NonPersistedEventEnvelope>, config: MagekConfig) => {
-    const userApp = getUserApp(config)
-    return storeEvents(userApp, eventRegistry, eventEnvelopes, config)
-  },
+  store: (eventEnvelopes: Array<NonPersistedEventEnvelope>, config: MagekConfig) =>
+    storeEvents(eventRegistry, eventEnvelopes, config),
   storeSnapshot: (snapshotEnvelope: NonPersistedEntitySnapshotEnvelope, config: MagekConfig) =>
     storeSnapshot(eventRegistry, snapshotEnvelope, config),
   search: (config: MagekConfig, parameters: EventSearchParameters) =>
@@ -406,6 +431,8 @@ export const eventStore: EventStoreAdapter = {
     },
     urls: async () => ['memory://in-memory-event-store'],
   },
+  fetchUnprocessedEvents: (config: MagekConfig) => fetchUnprocessedEvents(eventRegistry, config),
+  markEventProcessed: (config: MagekConfig, eventId: UUID) => markEventProcessed(eventRegistry, config, eventId),
 }
 
 // Export components for testing

--- a/adapters/memory/event-store/src/memory-event-registry.ts
+++ b/adapters/memory/event-store/src/memory-event-registry.ts
@@ -1,0 +1,277 @@
+import {
+  EntitySnapshotEnvelope,
+  EventEnvelope,
+  UUID,
+} from '@magek/common'
+
+export class MemoryEventRegistry {
+  private events: Map<string, EventEnvelope> = new Map()
+  private snapshots: Map<string, EntitySnapshotEnvelope> = new Map()
+  private dispatched: Set<string> = new Set()
+  private eventsByEntity: Map<string, Set<string>> = new Map()
+  private snapshotsByEntity: Map<string, Set<string>> = new Map()
+  private eventIdCounter = 0
+  private snapshotIdCounter = 0
+
+  private generateEventId(): string {
+    return `evt-${++this.eventIdCounter}-${Date.now()}`
+  }
+
+  private generateSnapshotId(): string {
+    return `snap-${++this.snapshotIdCounter}-${Date.now()}`
+  }
+
+  private getEntityKey(entityTypeName: string, entityID: UUID): string {
+    return `${entityTypeName}:${entityID}`
+  }
+
+  public async query(
+    query: QueryFilter,
+    sortOrder: 'asc' | 'desc' = 'asc',
+    limit?: number
+  ): Promise<Array<EventEnvelope | EntitySnapshotEnvelope>> {
+    const results: Array<EventEnvelope | EntitySnapshotEnvelope> = []
+
+    // Query events
+    if (!query.kind || query.kind === 'event') {
+      for (const event of Array.from(this.events.values())) {
+        if (this.matchesFilter(event, query)) {
+          results.push(event)
+        }
+      }
+    }
+
+    // Query snapshots
+    if (query.kind === 'snapshot') {
+      for (const snapshot of Array.from(this.snapshots.values())) {
+        if (this.matchesFilter(snapshot, query)) {
+          results.push(snapshot)
+        }
+      }
+    }
+
+    // Sort by createdAt
+    results.sort((a, b) => {
+      const aTime = new Date((a as EventEnvelope).createdAt ?? 0).getTime()
+      const bTime = new Date((b as EventEnvelope).createdAt ?? 0).getTime()
+      return sortOrder === 'asc' ? aTime - bTime : bTime - aTime
+    })
+
+    // Apply limit
+    if (limit && limit > 0) {
+      return results.slice(0, limit)
+    }
+
+    return results
+  }
+
+  public async queryLatestSnapshot(query: QueryFilter): Promise<EntitySnapshotEnvelope | undefined> {
+    const matchingSnapshots: EntitySnapshotEnvelope[] = []
+
+    for (const snapshot of Array.from(this.snapshots.values())) {
+      if (this.matchesFilter(snapshot, { ...query, kind: 'snapshot' })) {
+        matchingSnapshots.push(snapshot)
+      }
+    }
+
+    if (matchingSnapshots.length === 0) {
+      return undefined
+    }
+
+    // Sort by snapshottedEventCreatedAt descending and return the first one
+    matchingSnapshots.sort((a, b) => {
+      const aTime = new Date(a.snapshottedEventCreatedAt).getTime()
+      const bTime = new Date(b.snapshottedEventCreatedAt).getTime()
+      return bTime - aTime
+    })
+
+    return matchingSnapshots[0]
+  }
+
+  public async store(envelope: EventEnvelope | EntitySnapshotEnvelope): Promise<string> {
+    if (envelope.kind === 'event') {
+      const eventEnvelope = envelope as EventEnvelope
+      const id = this.generateEventId()
+      const storedEnvelope = { ...eventEnvelope, id }
+      this.events.set(id, storedEnvelope)
+
+      // Index by entity
+      const entityKey = this.getEntityKey(eventEnvelope.entityTypeName, eventEnvelope.entityID)
+      if (!this.eventsByEntity.has(entityKey)) {
+        this.eventsByEntity.set(entityKey, new Set())
+      }
+      this.eventsByEntity.get(entityKey)!.add(id)
+
+      return id
+    } else {
+      const snapshotEnvelope = envelope as EntitySnapshotEnvelope
+      const id = this.generateSnapshotId()
+      const storedEnvelope = { ...snapshotEnvelope, id }
+      this.snapshots.set(id, storedEnvelope)
+
+      // Index by entity
+      const entityKey = this.getEntityKey(snapshotEnvelope.entityTypeName, snapshotEnvelope.entityID)
+      if (!this.snapshotsByEntity.has(entityKey)) {
+        this.snapshotsByEntity.set(entityKey, new Set())
+      }
+      this.snapshotsByEntity.get(entityKey)!.add(id)
+
+      return id
+    }
+  }
+
+  public async storeDispatched(eventId: string): Promise<boolean> {
+    if (this.dispatched.has(eventId)) {
+      return false
+    }
+    this.dispatched.add(eventId)
+    return true
+  }
+
+  public async replaceOrDeleteItem(id: string, newValue?: EventEnvelope | EntitySnapshotEnvelope): Promise<void> {
+    // Check in events
+    if (this.events.has(id)) {
+      if (newValue) {
+        this.events.set(id, newValue as EventEnvelope)
+      } else {
+        const event = this.events.get(id)!
+        const entityKey = this.getEntityKey(event.entityTypeName, event.entityID)
+        this.eventsByEntity.get(entityKey)?.delete(id)
+        this.events.delete(id)
+      }
+      return
+    }
+
+    // Check in snapshots
+    if (this.snapshots.has(id)) {
+      if (newValue) {
+        this.snapshots.set(id, newValue as EntitySnapshotEnvelope)
+      } else {
+        const snapshot = this.snapshots.get(id)!
+        const entityKey = this.getEntityKey(snapshot.entityTypeName, snapshot.entityID)
+        this.snapshotsByEntity.get(entityKey)?.delete(id)
+        this.snapshots.delete(id)
+      }
+    }
+  }
+
+  public async deleteAll(): Promise<number> {
+    const count = this.events.size + this.snapshots.size
+    this.events.clear()
+    this.snapshots.clear()
+    this.dispatched.clear()
+    this.eventsByEntity.clear()
+    this.snapshotsByEntity.clear()
+    return count
+  }
+
+  public async count(query?: QueryFilter): Promise<number> {
+    if (!query) {
+      return this.events.size + this.snapshots.size
+    }
+
+    let count = 0
+
+    if (!query.kind || query.kind === 'event') {
+      for (const event of Array.from(this.events.values())) {
+        if (this.matchesFilter(event, query)) {
+          count++
+        }
+      }
+    }
+
+    if (query.kind === 'snapshot') {
+      for (const snapshot of Array.from(this.snapshots.values())) {
+        if (this.matchesFilter(snapshot, query)) {
+          count++
+        }
+      }
+    }
+
+    return count
+  }
+
+  public getEventsCount(): number {
+    return this.events.size
+  }
+
+  public getSnapshotsCount(): number {
+    return this.snapshots.size
+  }
+
+  private matchesFilter(envelope: EventEnvelope | EntitySnapshotEnvelope, query: QueryFilter): boolean {
+    // Check kind
+    if (query.kind && envelope.kind !== query.kind) {
+      return false
+    }
+
+    // Check entityTypeName
+    if (query.entityTypeName && envelope.entityTypeName !== query.entityTypeName) {
+      return false
+    }
+
+    // Check entityID
+    if (query.entityID && envelope.entityID !== query.entityID) {
+      return false
+    }
+
+    // Check typeName
+    if (query.typeName && envelope.typeName !== query.typeName) {
+      return false
+    }
+
+    // Check createdAt conditions
+    const envelopeCreatedAt = (envelope as EventEnvelope).createdAt
+    if (query.createdAt && envelopeCreatedAt) {
+      if (typeof query.createdAt === 'object') {
+        const conditions = query.createdAt as CreatedAtConditions
+        const envelopeTime = new Date(envelopeCreatedAt).getTime()
+
+        if (conditions.$gt) {
+          const gtTime = new Date(conditions.$gt).getTime()
+          if (envelopeTime <= gtTime) return false
+        }
+        if (conditions.$gte) {
+          const gteTime = new Date(conditions.$gte).getTime()
+          if (envelopeTime < gteTime) return false
+        }
+        if (conditions.$lt) {
+          const ltTime = new Date(conditions.$lt).getTime()
+          if (envelopeTime >= ltTime) return false
+        }
+        if (conditions.$lte) {
+          const lteTime = new Date(conditions.$lte).getTime()
+          if (envelopeTime > lteTime) return false
+        }
+      } else if (envelopeCreatedAt !== query.createdAt) {
+        return false
+      }
+    }
+
+    // Check deletedAt exists condition
+    if (query.deletedAt !== undefined) {
+      if (typeof query.deletedAt === 'object' && '$exists' in query.deletedAt) {
+        const hasDeletedAt = (envelope as EventEnvelope).deletedAt !== undefined
+        if (query.deletedAt.$exists !== hasDeletedAt) return false
+      }
+    }
+
+    return true
+  }
+}
+
+interface CreatedAtConditions {
+  $gt?: string
+  $gte?: string
+  $lt?: string
+  $lte?: string
+}
+
+export interface QueryFilter {
+  kind?: 'event' | 'snapshot'
+  entityTypeName?: string
+  entityID?: UUID
+  typeName?: string
+  createdAt?: string | CreatedAtConditions
+  deletedAt?: { $exists: boolean }
+}

--- a/adapters/memory/event-store/src/memory-event-registry.ts
+++ b/adapters/memory/event-store/src/memory-event-registry.ts
@@ -200,6 +200,11 @@ export class MemoryEventRegistry {
   }
 
   private matchesFilter(envelope: EventEnvelope | EntitySnapshotEnvelope, query: QueryFilter): boolean {
+    // Check _id
+    if (query._id && (envelope as EventEnvelope).id !== query._id) {
+      return false
+    }
+
     // Check kind
     if (query.kind && envelope.kind !== query.kind) {
       return false
@@ -256,7 +261,22 @@ export class MemoryEventRegistry {
       }
     }
 
+    // Check processedAt exists condition
+    if (query.processedAt !== undefined) {
+      if (typeof query.processedAt === 'object' && '$exists' in query.processedAt) {
+        const hasProcessedAt = (envelope as EventEnvelope).processedAt !== undefined
+        if (query.processedAt.$exists !== hasProcessedAt) return false
+      }
+    }
+
     return true
+  }
+
+  public async markProcessed(id: string, processedAt: string): Promise<void> {
+    const event = this.events.get(id)
+    if (event) {
+      this.events.set(id, { ...event, processedAt })
+    }
   }
 }
 
@@ -274,4 +294,6 @@ export interface QueryFilter {
   typeName?: string
   createdAt?: string | CreatedAtConditions
   deletedAt?: { $exists: boolean }
+  processedAt?: { $exists: boolean }
+  _id?: string
 }

--- a/adapters/memory/event-store/test/expect.ts
+++ b/adapters/memory/event-store/test/expect.ts
@@ -1,0 +1,8 @@
+import * as chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { default as sinonChai } from 'sinon-chai'
+
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+
+export const expect = chai.expect

--- a/adapters/memory/event-store/test/memory-event-store.test.ts
+++ b/adapters/memory/event-store/test/memory-event-store.test.ts
@@ -1,0 +1,297 @@
+import { expect } from './expect'
+import { MemoryEventRegistry } from '../src/memory-event-registry'
+import {
+  EventEnvelope,
+  EntitySnapshotEnvelope,
+} from '@magek/common'
+import { faker } from '@faker-js/faker'
+
+describe('MemoryEventRegistry', () => {
+  let registry: MemoryEventRegistry
+
+  beforeEach(() => {
+    registry = new MemoryEventRegistry()
+  })
+
+  function createMockEventEnvelope(overrides?: Partial<EventEnvelope>): EventEnvelope {
+    return {
+      kind: 'event',
+      superKind: 'domain',
+      typeName: faker.string.alphanumeric(10),
+      entityTypeName: faker.string.alphanumeric(10),
+      entityID: faker.string.uuid(),
+      value: { data: faker.string.alphanumeric(20) },
+      version: 1,
+      requestID: faker.string.uuid(),
+      createdAt: new Date().toISOString(),
+      ...overrides,
+    }
+  }
+
+  function createMockSnapshotEnvelope(overrides?: Partial<EntitySnapshotEnvelope>): EntitySnapshotEnvelope {
+    const now = new Date().toISOString()
+    return {
+      kind: 'snapshot',
+      superKind: 'domain',
+      typeName: faker.string.alphanumeric(10),
+      entityTypeName: faker.string.alphanumeric(10),
+      entityID: faker.string.uuid(),
+      value: { data: faker.string.alphanumeric(20) },
+      version: 1,
+      requestID: faker.string.uuid(),
+      snapshottedEventCreatedAt: now,
+      createdAt: now,
+      persistedAt: now,
+      ...overrides,
+    }
+  }
+
+  describe('store and query', () => {
+    it('should store and retrieve an event', async () => {
+      const event = createMockEventEnvelope()
+
+      await registry.store(event)
+
+      const results = await registry.query({ kind: 'event' })
+      expect(results).to.have.length(1)
+      expect(results[0]).to.include({
+        typeName: event.typeName,
+        entityTypeName: event.entityTypeName,
+        entityID: event.entityID,
+      })
+    })
+
+    it('should store and retrieve a snapshot', async () => {
+      const snapshot = createMockSnapshotEnvelope()
+
+      await registry.store(snapshot)
+
+      const results = await registry.query({ kind: 'snapshot' })
+      expect(results).to.have.length(1)
+      expect(results[0]).to.include({
+        typeName: snapshot.typeName,
+        entityTypeName: snapshot.entityTypeName,
+        entityID: snapshot.entityID,
+      })
+    })
+
+    it('should filter events by entityTypeName', async () => {
+      const entityTypeName = 'TestEntity'
+      const event1 = createMockEventEnvelope({ entityTypeName })
+      const event2 = createMockEventEnvelope({ entityTypeName: 'OtherEntity' })
+
+      await registry.store(event1)
+      await registry.store(event2)
+
+      const results = await registry.query({ kind: 'event', entityTypeName })
+      expect(results).to.have.length(1)
+      expect(results[0].entityTypeName).to.equal(entityTypeName)
+    })
+
+    it('should filter events by entityID', async () => {
+      const entityID = faker.string.uuid()
+      const event1 = createMockEventEnvelope({ entityID })
+      const event2 = createMockEventEnvelope()
+
+      await registry.store(event1)
+      await registry.store(event2)
+
+      const results = await registry.query({ kind: 'event', entityID })
+      expect(results).to.have.length(1)
+      expect(results[0].entityID).to.equal(entityID)
+    })
+
+    it('should filter by createdAt with $gt', async () => {
+      const pastDate = new Date(Date.now() - 10000).toISOString()
+      const futureDate = new Date(Date.now() + 10000).toISOString()
+
+      const event1 = createMockEventEnvelope({ createdAt: pastDate })
+      const event2 = createMockEventEnvelope({ createdAt: futureDate })
+
+      await registry.store(event1)
+      await registry.store(event2)
+
+      const results = await registry.query({
+        kind: 'event',
+        createdAt: { $gt: new Date().toISOString() },
+      })
+
+      expect(results).to.have.length(1)
+      expect(results[0].createdAt).to.equal(futureDate)
+    })
+
+    it('should filter by deletedAt $exists false', async () => {
+      const event1 = createMockEventEnvelope()
+      const event2 = createMockEventEnvelope({ deletedAt: new Date().toISOString() })
+
+      await registry.store(event1)
+      await registry.store(event2)
+
+      const results = await registry.query({
+        kind: 'event',
+        deletedAt: { $exists: false },
+      })
+
+      expect(results).to.have.length(1)
+    })
+
+    it('should sort results by createdAt ascending', async () => {
+      const event1 = createMockEventEnvelope({ createdAt: new Date(Date.now() + 1000).toISOString() })
+      const event2 = createMockEventEnvelope({ createdAt: new Date(Date.now() - 1000).toISOString() })
+
+      await registry.store(event1)
+      await registry.store(event2)
+
+      const results = await registry.query({ kind: 'event' }, 'asc')
+
+      expect(results[0].createdAt).to.equal(event2.createdAt)
+      expect(results[1].createdAt).to.equal(event1.createdAt)
+    })
+
+    it('should sort results by createdAt descending', async () => {
+      const event1 = createMockEventEnvelope({ createdAt: new Date(Date.now() + 1000).toISOString() })
+      const event2 = createMockEventEnvelope({ createdAt: new Date(Date.now() - 1000).toISOString() })
+
+      await registry.store(event1)
+      await registry.store(event2)
+
+      const results = await registry.query({ kind: 'event' }, 'desc')
+
+      expect(results[0].createdAt).to.equal(event1.createdAt)
+      expect(results[1].createdAt).to.equal(event2.createdAt)
+    })
+
+    it('should apply limit to results', async () => {
+      const event1 = createMockEventEnvelope()
+      const event2 = createMockEventEnvelope()
+      const event3 = createMockEventEnvelope()
+
+      await registry.store(event1)
+      await registry.store(event2)
+      await registry.store(event3)
+
+      const results = await registry.query({ kind: 'event' }, 'asc', 2)
+
+      expect(results).to.have.length(2)
+    })
+  })
+
+  describe('queryLatestSnapshot', () => {
+    it('should return the latest snapshot for an entity', async () => {
+      const entityTypeName = 'TestEntity'
+      const entityID = faker.string.uuid()
+
+      const olderSnapshot = createMockSnapshotEnvelope({
+        entityTypeName,
+        entityID,
+        snapshottedEventCreatedAt: new Date(Date.now() - 10000).toISOString(),
+      })
+      const newerSnapshot = createMockSnapshotEnvelope({
+        entityTypeName,
+        entityID,
+        snapshottedEventCreatedAt: new Date(Date.now() + 10000).toISOString(),
+      })
+
+      await registry.store(olderSnapshot)
+      await registry.store(newerSnapshot)
+
+      const result = await registry.queryLatestSnapshot({ entityTypeName, entityID })
+
+      expect(result).to.not.be.undefined
+      expect(result!.snapshottedEventCreatedAt).to.equal(newerSnapshot.snapshottedEventCreatedAt)
+    })
+
+    it('should return undefined when no snapshot exists', async () => {
+      const result = await registry.queryLatestSnapshot({
+        entityTypeName: 'NonExistent',
+        entityID: faker.string.uuid(),
+      })
+
+      expect(result).to.be.undefined
+    })
+  })
+
+  describe('storeDispatched', () => {
+    it('should return true for first dispatch of an event', async () => {
+      const eventId = 'test-event-1'
+
+      const result = await registry.storeDispatched(eventId)
+
+      expect(result).to.be.true
+    })
+
+    it('should return false for duplicate dispatch', async () => {
+      const eventId = 'test-event-1'
+
+      await registry.storeDispatched(eventId)
+      const result = await registry.storeDispatched(eventId)
+
+      expect(result).to.be.false
+    })
+  })
+
+  describe('replaceOrDeleteItem', () => {
+    it('should soft delete an event by replacing it', async () => {
+      const event = createMockEventEnvelope()
+      const id = await registry.store(event)
+
+      const deletedEvent = {
+        ...event,
+        id,
+        deletedAt: new Date().toISOString(),
+        value: {},
+      } as EventEnvelope
+
+      await registry.replaceOrDeleteItem(id, deletedEvent)
+
+      const results = await registry.query({ kind: 'event', deletedAt: { $exists: false } })
+      expect(results).to.have.length(0)
+    })
+
+    it('should hard delete a snapshot', async () => {
+      const snapshot = createMockSnapshotEnvelope()
+      const id = await registry.store(snapshot)
+
+      await registry.replaceOrDeleteItem(id)
+
+      const results = await registry.query({ kind: 'snapshot' })
+      expect(results).to.have.length(0)
+    })
+  })
+
+  describe('deleteAll', () => {
+    it('should delete all events and snapshots', async () => {
+      await registry.store(createMockEventEnvelope())
+      await registry.store(createMockEventEnvelope())
+      await registry.store(createMockSnapshotEnvelope())
+
+      const count = await registry.deleteAll()
+
+      expect(count).to.equal(3)
+      expect(registry.getEventsCount()).to.equal(0)
+      expect(registry.getSnapshotsCount()).to.equal(0)
+    })
+  })
+
+  describe('count', () => {
+    it('should return total count without filter', async () => {
+      await registry.store(createMockEventEnvelope())
+      await registry.store(createMockEventEnvelope())
+      await registry.store(createMockSnapshotEnvelope())
+
+      const count = await registry.count()
+
+      expect(count).to.equal(3)
+    })
+
+    it('should return filtered count', async () => {
+      const entityTypeName = 'TestEntity'
+      await registry.store(createMockEventEnvelope({ entityTypeName }))
+      await registry.store(createMockEventEnvelope({ entityTypeName: 'OtherEntity' }))
+
+      const count = await registry.count({ kind: 'event', entityTypeName })
+
+      expect(count).to.equal(1)
+    })
+  })
+})

--- a/adapters/memory/event-store/test/memory-event-store.test.ts
+++ b/adapters/memory/event-store/test/memory-event-store.test.ts
@@ -294,4 +294,74 @@ describe('MemoryEventRegistry', () => {
       expect(count).to.equal(1)
     })
   })
+
+  describe('processedAt filtering', () => {
+    it('should filter by processedAt $exists false', async () => {
+      const event1 = createMockEventEnvelope()
+      const event2 = createMockEventEnvelope({ processedAt: new Date().toISOString() })
+
+      await registry.store(event1)
+      await registry.store(event2)
+
+      const results = await registry.query({
+        kind: 'event',
+        processedAt: { $exists: false },
+      })
+
+      expect(results).to.have.length(1)
+    })
+
+    it('should filter by processedAt $exists true', async () => {
+      const event1 = createMockEventEnvelope()
+      const event2 = createMockEventEnvelope({ processedAt: new Date().toISOString() })
+
+      await registry.store(event1)
+      await registry.store(event2)
+
+      const results = await registry.query({
+        kind: 'event',
+        processedAt: { $exists: true },
+      })
+
+      expect(results).to.have.length(1)
+      expect((results[0] as EventEnvelope).processedAt).to.not.be.undefined
+    })
+  })
+
+  describe('_id filtering', () => {
+    it('should filter by _id', async () => {
+      const event1 = createMockEventEnvelope()
+      const event2 = createMockEventEnvelope()
+
+      const id1 = await registry.store(event1)
+      await registry.store(event2)
+
+      const results = await registry.query({
+        kind: 'event',
+        _id: id1,
+      })
+
+      expect(results).to.have.length(1)
+      expect((results[0] as EventEnvelope).id).to.equal(id1)
+    })
+  })
+
+  describe('markProcessed', () => {
+    it('should mark an event as processed', async () => {
+      const event = createMockEventEnvelope()
+      const id = await registry.store(event)
+
+      const processedAt = new Date().toISOString()
+      await registry.markProcessed(id, processedAt)
+
+      const results = await registry.query({ kind: 'event', _id: id })
+      expect(results).to.have.length(1)
+      expect((results[0] as EventEnvelope).processedAt).to.equal(processedAt)
+    })
+
+    it('should not fail when marking a non-existent event', async () => {
+      // Should not throw
+      await registry.markProcessed('non-existent-id', new Date().toISOString())
+    })
+  })
 })

--- a/adapters/memory/event-store/tsconfig.eslint.json
+++ b/adapters/memory/event-store/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/adapters/memory/event-store/tsconfig.json
+++ b/adapters/memory/event-store/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/adapters/memory/event-store/tsconfig.test.json
+++ b/adapters/memory/event-store/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {"rootDir": "."},
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/adapters/memory/read-model-store/.mocharc.yml
+++ b/adapters/memory/read-model-store/.mocharc.yml
@@ -1,0 +1,11 @@
+diff: true
+require: tsx/cjs
+extension:
+  - ts
+package: './package.json'
+recursive: true
+reporter: 'spec'
+timeout: 5000
+full-trace: true
+bail: true
+color: true

--- a/adapters/memory/read-model-store/eslint.config.mjs
+++ b/adapters/memory/read-model-store/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.eslint.json'
+      }
+    }
+  }
+]

--- a/adapters/memory/read-model-store/package.json
+++ b/adapters/memory/read-model-store/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@magek/adapter-read-model-store-memory",
+  "version": "0.0.6",
+  "description": "In-memory read model store adapter for the Magek framework",
+  "keywords": [
+    "read-model-store",
+    "memory",
+    "in-memory"
+  ],
+  "author": "Boosterin Labs SLU",
+  "homepage": "https://magek.ai",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theam/magek.git"
+  },
+  "engines": {
+    "node": ">=22.0.0 <23.0.0"
+  },
+  "dependencies": {
+    "@magek/common": "workspace:^0.0.6",
+    "tslib": "2.8.1"
+  },
+  "scripts": {
+    "format": "prettier --write --ext '.js,.ts' **/*.ts **/*/*.ts",
+    "lint:check": "eslint \"**/*.ts\"",
+    "lint:fix": "eslint --quiet --fix \"**/*.ts\"",
+    "build": "tsc -b tsconfig.json",
+    "clean": "rimraf ./dist tsconfig.tsbuildinfo",
+    "prepack": "tsc -b tsconfig.json",
+    "test": "tsc --noEmit -p tsconfig.test.json && c8 mocha --forbid-only \"test/**/*.test.ts\""
+  },
+  "bugs": {
+    "url": "https://github.com/theam/magek/issues"
+  },
+  "devDependencies": {
+    "@magek/eslint-config": "workspace:^0.0.6",
+    "@types/chai": "5.2.3",
+    "@types/chai-as-promised": "8.0.2",
+    "@types/mocha": "10.0.10",
+    "@types/node": "22.19.7",
+    "@types/sinon": "21.0.0",
+    "@types/sinon-chai": "4.0.0",
+    "chai": "6.2.2",
+    "chai-as-promised": "8.0.2",
+    "@faker-js/faker": "10.2.0",
+    "mocha": "11.7.5",
+    "c8": "^10.1.3",
+    "rimraf": "6.1.2",
+    "sinon": "21.0.1",
+    "sinon-chai": "4.0.1",
+    "tsx": "^4.19.2",
+    "typescript": "5.9.3"
+  }
+}

--- a/adapters/memory/read-model-store/package.json
+++ b/adapters/memory/read-model-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magek/adapter-read-model-store-memory",
-  "version": "0.0.6",
+  "version": "0.0.10",
   "description": "In-memory read model store adapter for the Magek framework",
   "keywords": [
     "read-model-store",
@@ -25,7 +25,7 @@
     "node": ">=22.0.0 <23.0.0"
   },
   "dependencies": {
-    "@magek/common": "workspace:^0.0.6",
+    "@magek/common": "workspace:^0.0.10",
     "tslib": "2.8.1"
   },
   "scripts": {
@@ -41,7 +41,7 @@
     "url": "https://github.com/theam/magek/issues"
   },
   "devDependencies": {
-    "@magek/eslint-config": "workspace:^0.0.6",
+    "@magek/eslint-config": "workspace:^0.0.10",
     "@types/chai": "5.2.3",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",

--- a/adapters/memory/read-model-store/package.json
+++ b/adapters/memory/read-model-store/package.json
@@ -45,7 +45,7 @@
     "@types/chai": "5.2.3",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.19.7",
+    "@types/node": "22.19.8",
     "@types/sinon": "21.0.0",
     "@types/sinon-chai": "4.0.0",
     "chai": "6.2.2",

--- a/adapters/memory/read-model-store/src/index.ts
+++ b/adapters/memory/read-model-store/src/index.ts
@@ -1,0 +1,209 @@
+import {
+  MagekConfig,
+  ReadModelInterface,
+  ReadModelStoreAdapter,
+  ReadModelStoreEnvelope,
+  UUID,
+  FilterFor,
+  SortFor,
+  ProjectionFor,
+  ReadModelListResult,
+  SequenceKey,
+  ReadOnlyNonEmptyArray,
+  getLogger,
+  OptimisticConcurrencyUnexpectedVersionError,
+  ReadModelEnvelope,
+} from '@magek/common'
+import { MemoryReadModelRegistry, QueryFilter } from './memory-read-model-registry'
+
+// Pre-built Memory Read Model Store Adapter instance
+const readModelRegistry = new MemoryReadModelRegistry()
+
+async function fetchReadModel(
+  db: MemoryReadModelRegistry,
+  config: MagekConfig,
+  readModelName: string,
+  readModelID: UUID,
+  sequenceKey?: SequenceKey
+): Promise<ReadOnlyNonEmptyArray<ReadModelInterface> | undefined> {
+  const logger = getLogger(config, 'memory-read-model-adapter#fetchReadModel')
+
+  const query: QueryFilter = { typeName: readModelName, 'value.id': readModelID }
+
+  // If sequenceKey is provided, add it to the query
+  if (sequenceKey) {
+    query[`value.${sequenceKey.name}`] = sequenceKey.value
+  }
+
+  const response = await db.query(query)
+
+  if (response.length === 0) {
+    logger.debug(`Read model ${readModelName} with ID ${readModelID} not found`)
+    return undefined
+  }
+
+  logger.debug(
+    `Loaded read model ${readModelName} with ID ${readModelID} with result:`,
+    response.map((item) => item.value)
+  )
+  return response.map((item) => item.value) as unknown as ReadOnlyNonEmptyArray<ReadModelInterface>
+}
+
+async function storeReadModel(
+  db: MemoryReadModelRegistry,
+  config: MagekConfig,
+  readModelName: string,
+  readModel: ReadModelInterface,
+  expectedCurrentVersion: number
+): Promise<void> {
+  const logger = getLogger(config, 'memory-read-model-adapter#storeReadModel')
+  logger.debug('Storing readModel ' + JSON.stringify(readModel))
+  try {
+    await db.store({ typeName: readModelName, value: readModel } as ReadModelEnvelope, expectedCurrentVersion)
+  } catch (e) {
+    if (e instanceof OptimisticConcurrencyUnexpectedVersionError) {
+      logger.warn(
+        `Unique violated storing ReadModel ${JSON.stringify(readModel)} and expectedCurrentVersion ${expectedCurrentVersion}`
+      )
+      throw e
+    }
+    throw e
+  }
+  logger.debug('Read model stored')
+}
+
+async function searchReadModel<TReadModel extends ReadModelInterface>(
+  db: MemoryReadModelRegistry,
+  config: MagekConfig,
+  readModelName: string,
+  filters: FilterFor<unknown>,
+  sortBy?: SortFor<unknown>,
+  limit?: number,
+  afterCursor?: Record<string, string> | undefined,
+  paginatedVersion = false,
+  select?: ProjectionFor<TReadModel>
+): Promise<Array<TReadModel> | ReadModelListResult<TReadModel>> {
+  const logger = getLogger(config, 'memory-read-model-adapter#searchReadModel')
+  logger.debug('Converting filter to query')
+
+  const query: QueryFilter = { typeName: readModelName, filters }
+  logger.debug('Got query ', query)
+
+  const skipId = afterCursor?.id ? parseInt(afterCursor?.id) : 0
+  const result = await db.query(query, sortBy, skipId, limit, select as ProjectionFor<unknown>)
+  logger.debug('Search result: ', result)
+
+  const items: Array<TReadModel> = result?.map((envelope) => envelope.value as TReadModel) ?? []
+
+  if (paginatedVersion) {
+    return {
+      items: items,
+      count: items?.length ?? 0,
+      cursor: { id: ((limit ? limit : 1) + skipId).toString() },
+    } as ReadModelListResult<TReadModel>
+  }
+
+  return items
+}
+
+async function deleteReadModel(
+  db: MemoryReadModelRegistry,
+  config: MagekConfig,
+  readModelName: string,
+  readModel: ReadModelInterface
+): Promise<void> {
+  const logger = getLogger(config, 'memory-read-model-adapter#deleteReadModel')
+  logger.debug(`Entering to Read model deleted. ID=${readModel.id}.Name=${readModelName}`)
+  try {
+    await db.deleteById(readModel.id, readModelName)
+    logger.debug(`Read model deleted. ${readModelName} ID = ${readModel.id}`)
+  } catch (e) {
+    logger.warn(`Read model to delete ${readModelName} ID = ${readModel.id} not found`)
+  }
+}
+
+export const readModelStore: ReadModelStoreAdapter = {
+  fetch: async <TReadModel extends ReadModelInterface>(
+    config: MagekConfig,
+    readModelName: string,
+    readModelID: UUID,
+    sequenceKey?: SequenceKey
+  ): Promise<ReadOnlyNonEmptyArray<TReadModel> | undefined> => {
+    const result = await fetchReadModel(readModelRegistry, config, readModelName, readModelID, sequenceKey)
+    if (!result || result.length === 0) {
+      return undefined
+    }
+    return result as ReadOnlyNonEmptyArray<TReadModel>
+  },
+
+  search: async <TReadModel extends ReadModelInterface>(
+    config: MagekConfig,
+    readModelName: string,
+    filters: FilterFor<unknown>,
+    sortBy?: SortFor<unknown>,
+    limit?: number,
+    afterCursor?: unknown,
+    paginatedVersion?: boolean,
+    select?: ProjectionFor<TReadModel>
+  ): Promise<Array<TReadModel> | ReadModelListResult<TReadModel>> => {
+    return await searchReadModel<TReadModel>(
+      readModelRegistry,
+      config,
+      readModelName,
+      filters,
+      sortBy,
+      limit,
+      afterCursor as Record<string, string>,
+      paginatedVersion ?? false,
+      select
+    )
+  },
+
+  store: async <TReadModel extends ReadModelInterface>(
+    config: MagekConfig,
+    readModelName: string,
+    readModel: ReadModelStoreEnvelope<TReadModel>
+  ): Promise<ReadModelStoreEnvelope<TReadModel>> => {
+    const expectedCurrentVersion = (readModel.version ?? 1) - 1
+    await storeReadModel(readModelRegistry, config, readModelName, readModel.value, expectedCurrentVersion)
+
+    // Return the stored envelope with updated timestamps
+    return {
+      ...readModel,
+      updatedAt: new Date().toISOString(),
+    }
+  },
+
+  delete: async (config: MagekConfig, readModelName: string, readModelID: UUID): Promise<void> => {
+    // Create a minimal ReadModelInterface for the delete operation
+    const readModel: ReadModelInterface = {
+      id: readModelID,
+    }
+    await deleteReadModel(readModelRegistry, config, readModelName, readModel)
+  },
+
+  rawToEnvelopes: async <TReadModel extends ReadModelInterface>(
+    config: MagekConfig,
+    rawReadModels: unknown
+  ): Promise<Array<ReadModelStoreEnvelope<TReadModel>>> => {
+    // This would typically convert raw database records to envelopes
+    // For now, assume rawReadModels is already in the correct format
+    return rawReadModels as Array<ReadModelStoreEnvelope<TReadModel>>
+  },
+
+  healthCheck: {
+    isUp: async (): Promise<boolean> => true,
+    details: async (): Promise<unknown> => {
+      return {
+        type: 'memory',
+        count: readModelRegistry.getCount(),
+      }
+    },
+    urls: async (): Promise<Array<string>> => ['memory://in-memory-read-model-store'],
+  },
+}
+
+// Export individual components for backward compatibility and testing
+export { MemoryReadModelRegistry } from './memory-read-model-registry'
+export { evaluateFilter, convertFilter } from './library/filter-evaluator'
+export { fetchReadModel, storeReadModel, searchReadModel, deleteReadModel }

--- a/adapters/memory/read-model-store/src/library/filter-evaluator.ts
+++ b/adapters/memory/read-model-store/src/library/filter-evaluator.ts
@@ -1,0 +1,270 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type FilterValue = number | string | boolean | null | undefined
+
+export interface EvaluatedFilter {
+  [key: string]: FilterOperation
+}
+
+export type FilterOperation =
+  | FilterValue
+  | { $eq?: FilterValue }
+  | { $ne?: FilterValue }
+  | { $lt?: FilterValue }
+  | { $gt?: FilterValue }
+  | { $lte?: FilterValue }
+  | { $gte?: FilterValue }
+  | { $in?: FilterValue[] }
+  | { $exists?: boolean }
+  | { $regex?: RegExp }
+  | { $elemMatch?: FilterValue }
+  | { $and?: EvaluatedFilter[] }
+  | { $or?: EvaluatedFilter[] }
+  | { $not?: EvaluatedFilter }
+
+/**
+ * Evaluates a filter against a value object.
+ * Returns true if the value matches the filter conditions.
+ */
+export function evaluateFilter(value: Record<string, any>, filters: any): boolean {
+  if (!filters || Object.keys(filters).length === 0) {
+    return true
+  }
+
+  for (const key in filters) {
+    const filterValue = filters[key]
+
+    // Handle logical operators
+    if (key === 'and') {
+      const andFilters = filterValue as any[]
+      if (!andFilters.every((f) => evaluateFilter(value, f))) {
+        return false
+      }
+      continue
+    }
+
+    if (key === 'or') {
+      const orFilters = filterValue as any[]
+      if (!orFilters.some((f) => evaluateFilter(value, f))) {
+        return false
+      }
+      continue
+    }
+
+    if (key === 'not') {
+      if (evaluateFilter(value, filterValue)) {
+        return false
+      }
+      continue
+    }
+
+    // Handle field-level filters
+    const fieldValue = getNestedValue(value, key)
+    if (!evaluateFieldFilter(fieldValue, filterValue)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Gets a nested value from an object using dot notation.
+ */
+function getNestedValue(obj: Record<string, any>, path: string): any {
+  const parts = path.split('.')
+  let current: any = obj
+
+  for (const part of parts) {
+    if (current === null || current === undefined) {
+      return undefined
+    }
+    current = current[part]
+  }
+
+  return current
+}
+
+/**
+ * Evaluates a filter against a single field value.
+ */
+function evaluateFieldFilter(fieldValue: any, filter: any): boolean {
+  if (filter === null || filter === undefined) {
+    return true
+  }
+
+  // If filter is a primitive, it's an implicit eq operation
+  if (typeof filter !== 'object') {
+    return fieldValue === filter
+  }
+
+  // Check for filter operations
+  const filterKeys = Object.keys(filter)
+
+  for (const op of filterKeys) {
+    const opValue = filter[op]
+
+    switch (op) {
+      case 'eq':
+        if (fieldValue !== opValue) return false
+        break
+
+      case 'ne':
+        if (fieldValue === opValue) return false
+        break
+
+      case 'lt':
+        if (fieldValue >= opValue) return false
+        break
+
+      case 'gt':
+        if (fieldValue <= opValue) return false
+        break
+
+      case 'lte':
+        if (fieldValue > opValue) return false
+        break
+
+      case 'gte':
+        if (fieldValue < opValue) return false
+        break
+
+      case 'in':
+        if (!Array.isArray(opValue) || !opValue.includes(fieldValue)) return false
+        break
+
+      case 'isDefined': {
+        const exists = fieldValue !== undefined && fieldValue !== null
+        if (opValue !== exists) return false
+        break
+      }
+
+      case 'contains':
+        if (typeof fieldValue !== 'string' || !fieldValue.includes(opValue as string)) return false
+        break
+
+      case 'beginsWith':
+        if (typeof fieldValue !== 'string' || !fieldValue.startsWith(opValue as string)) return false
+        break
+
+      case 'regex':
+        if (typeof fieldValue !== 'string') return false
+        try {
+          const regex = new RegExp(opValue as string)
+          if (!regex.test(fieldValue)) return false
+        } catch {
+          return false
+        }
+        break
+
+      case 'iRegex':
+        if (typeof fieldValue !== 'string') return false
+        try {
+          const regex = new RegExp(opValue as string, 'i')
+          if (!regex.test(fieldValue)) return false
+        } catch {
+          return false
+        }
+        break
+
+      case 'includes':
+        if (!Array.isArray(fieldValue)) return false
+        if (typeof opValue === 'string') {
+          // Check if any element contains the string
+          if (!fieldValue.some((item) => typeof item === 'string' && item.includes(opValue))) return false
+        } else {
+          // Check if array includes the value (elemMatch-like)
+          if (!fieldValue.some((item) => {
+            if (typeof opValue === 'object' && opValue !== null) {
+              return evaluateFilter(item as Record<string, any>, opValue)
+            }
+            return item === opValue
+          })) return false
+        }
+        break
+
+      default:
+        // If the key is not a known operator, it might be a nested filter
+        if (!evaluateFieldFilter(getNestedValue(fieldValue, op), filter[op])) {
+          return false
+        }
+    }
+  }
+
+  return true
+}
+
+/**
+ * Converts a GraphQL filter to an evaluated filter structure.
+ * This function transforms Magek-style filters into a format that can be
+ * efficiently evaluated against data.
+ */
+export function convertFilter(filters: any, prefix = ''): EvaluatedFilter {
+  const result: EvaluatedFilter = {}
+
+  for (const key in filters) {
+    const filterValue = filters[key]
+    const fullKey = prefix ? `${prefix}.${key}` : key
+
+    if (key === 'and' || key === 'or') {
+      const logicalFilters = (filterValue as any[]).map((f) => convertFilter(f))
+      result[`$${key}`] = logicalFilters as any
+    } else if (key === 'not') {
+      result['$not'] = convertFilter(filterValue) as any
+    } else if (typeof filterValue === 'object' && filterValue !== null) {
+      // Check if this is a filter operation object
+      const opKeys = Object.keys(filterValue)
+      const isFilterOp = opKeys.some((k) =>
+        ['eq', 'ne', 'lt', 'gt', 'lte', 'gte', 'in', 'isDefined', 'contains', 'beginsWith', 'regex', 'iRegex', 'includes'].includes(k)
+      )
+
+      if (isFilterOp) {
+        result[fullKey] = convertFilterOperation(filterValue)
+      } else {
+        // Nested object filter
+        Object.assign(result, convertFilter(filterValue, fullKey))
+      }
+    } else {
+      result[fullKey] = filterValue as FilterOperation
+    }
+  }
+
+  return result
+}
+
+function convertFilterOperation(filter: any): FilterOperation {
+  const op = Object.keys(filter)[0]
+  const value = filter[op]
+
+  switch (op) {
+    case 'eq':
+      return { $eq: value }
+    case 'ne':
+      return { $ne: value }
+    case 'lt':
+      return { $lt: value }
+    case 'gt':
+      return { $gt: value }
+    case 'lte':
+      return { $lte: value }
+    case 'gte':
+      return { $gte: value }
+    case 'in':
+      return { $in: value }
+    case 'isDefined':
+      return { $exists: value }
+    case 'contains':
+    case 'beginsWith':
+    case 'regex':
+      return { $regex: new RegExp(op === 'beginsWith' ? `^${value}` : value) }
+    case 'iRegex':
+      return { $regex: new RegExp(value, 'i') }
+    case 'includes':
+      if (typeof value === 'string') {
+        return { $regex: new RegExp(value) }
+      }
+      return { $elemMatch: value }
+    default:
+      return value
+  }
+}

--- a/adapters/memory/read-model-store/src/memory-read-model-registry.ts
+++ b/adapters/memory/read-model-store/src/memory-read-model-registry.ts
@@ -1,0 +1,303 @@
+import {
+  ReadModelEnvelope,
+  SortFor,
+  ProjectionFor,
+  UUID,
+  OptimisticConcurrencyUnexpectedVersionError,
+} from '@magek/common'
+import { evaluateFilter } from './library/filter-evaluator'
+
+export interface ReadModelStoreEntry extends ReadModelEnvelope {
+  uniqueKey: string
+}
+
+interface LocalSortedFor {
+  [key: string]: number
+}
+
+export class MemoryReadModelRegistry {
+  private readModels: Map<string, ReadModelStoreEntry> = new Map()
+  private byType: Map<string, Set<string>> = new Map()
+
+  private getKey(typeName: string, id: UUID): string {
+    return `${typeName}:${id}`
+  }
+
+  public async query(
+    query: QueryFilter,
+    sortBy?: SortFor<unknown>,
+    skip?: number,
+    limit?: number,
+    select?: ProjectionFor<unknown>
+  ): Promise<Array<ReadModelEnvelope>> {
+    let results: ReadModelEnvelope[] = []
+
+    // Filter by typeName first if provided
+    if (query.typeName) {
+      const typeKeys = this.byType.get(query.typeName)
+      if (typeKeys) {
+        for (const key of Array.from(typeKeys)) {
+          const entry = this.readModels.get(key)
+          if (entry && this.matchesFilter(entry, query)) {
+            results.push(entry)
+          }
+        }
+      }
+    } else {
+      // Query all read models
+      for (const entry of Array.from(this.readModels.values())) {
+        if (this.matchesFilter(entry, query)) {
+          results.push(entry)
+        }
+      }
+    }
+
+    // Apply sorting
+    if (sortBy && Object.keys(sortBy).length > 0) {
+      const sortedList = this.toLocalSortFor(sortBy)
+      if (sortedList) {
+        results = this.sortResults(results, sortedList)
+      }
+    }
+
+    // Apply skip
+    if (skip && skip > 0) {
+      results = results.slice(skip)
+    }
+
+    // Apply limit
+    if (limit && limit > 0) {
+      results = results.slice(0, limit)
+    }
+
+    // Apply select (field projection)
+    if (select && select.length > 0) {
+      results = results.map((result) => ({
+        ...result,
+        value: this.filterFields(result.value, select),
+      }))
+    }
+
+    return results
+  }
+
+  public async store(readModel: ReadModelEnvelope, expectedCurrentVersion: number): Promise<void> {
+    const key = this.getKey(readModel.typeName, readModel.value.id)
+    const version = readModel.value.magekMetadata?.version ?? 1
+    const uniqueKey = `${readModel.typeName}_${readModel.value.id}_${version}`
+
+    const entry: ReadModelStoreEntry = {
+      ...readModel,
+      uniqueKey,
+    }
+
+    if (version === 1) {
+      // Insert new read model
+      this.readModels.set(key, entry)
+
+      // Index by type
+      if (!this.byType.has(readModel.typeName)) {
+        this.byType.set(readModel.typeName, new Set())
+      }
+      this.byType.get(readModel.typeName)!.add(key)
+    } else {
+      // Update existing read model with optimistic concurrency check
+      const existing = this.readModels.get(key)
+
+      if (!existing) {
+        throw new OptimisticConcurrencyUnexpectedVersionError(
+          `Can't update readModel ${JSON.stringify(readModel)} with expectedCurrentVersion = ${expectedCurrentVersion}. Read model not found.`
+        )
+      }
+
+      const existingVersion = existing.value.magekMetadata?.version ?? 0
+
+      if (existingVersion !== expectedCurrentVersion) {
+        throw new OptimisticConcurrencyUnexpectedVersionError(
+          `Can't update readModel ${JSON.stringify(readModel)} with expectedCurrentVersion = ${expectedCurrentVersion}. Current version is ${existingVersion}.`
+        )
+      }
+
+      this.readModels.set(key, entry)
+    }
+  }
+
+  public async deleteById(id: UUID, typeName: string): Promise<number> {
+    const key = this.getKey(typeName, id)
+    const exists = this.readModels.has(key)
+
+    if (exists) {
+      this.readModels.delete(key)
+      this.byType.get(typeName)?.delete(key)
+      return 1
+    }
+
+    return 0
+  }
+
+  public async deleteAll(): Promise<number> {
+    const count = this.readModels.size
+    this.readModels.clear()
+    this.byType.clear()
+    return count
+  }
+
+  public async count(query?: QueryFilter): Promise<number> {
+    if (!query) {
+      return this.readModels.size
+    }
+
+    let count = 0
+    for (const entry of Array.from(this.readModels.values())) {
+      if (this.matchesFilter(entry, query)) {
+        count++
+      }
+    }
+
+    return count
+  }
+
+  public getCount(): number {
+    return this.readModels.size
+  }
+
+  private matchesFilter(entry: ReadModelEnvelope, query: QueryFilter): boolean {
+    // Check typeName
+    if (query.typeName && entry.typeName !== query.typeName) {
+      return false
+    }
+
+    // Check value.id
+    if (query['value.id'] && entry.value.id !== query['value.id']) {
+      return false
+    }
+
+    // Check sequence key if present
+    for (const key of Object.keys(query)) {
+      if (key.startsWith('value.') && key !== 'value.id') {
+        const fieldPath = key.substring(6) // Remove 'value.' prefix
+        const fieldValue = this.getNestedValue(entry.value, fieldPath)
+        if (fieldValue !== query[key]) {
+          return false
+        }
+      }
+    }
+
+    // Check GraphQL-style filters
+    if (query.filters) {
+      if (!evaluateFilter(entry.value, query.filters)) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  private getNestedValue(obj: Record<string, any>, path: string): any {
+    const parts = path.split('.')
+    let current = obj
+
+    for (const part of parts) {
+      if (current === null || current === undefined) {
+        return undefined
+      }
+      current = current[part]
+    }
+
+    return current
+  }
+
+  private toLocalSortFor(
+    sortBy?: SortFor<unknown>,
+    parentKey = '',
+    sortedList: LocalSortedFor = Object.create(null)
+  ): undefined | LocalSortedFor {
+    if (!sortBy || Object.keys(sortBy).length === 0) return undefined
+
+    Object.entries(sortBy).forEach(([key, value]) => {
+      if (typeof value === 'string') {
+        sortedList[`value.${parentKey}${key}`] = (value as string) === 'ASC' ? 1 : -1
+      } else {
+        this.toLocalSortFor(value as SortFor<unknown>, `${parentKey}${key}.`, sortedList)
+      }
+    })
+
+    return sortedList
+  }
+
+  private sortResults(results: ReadModelEnvelope[], sortedList: LocalSortedFor): ReadModelEnvelope[] {
+    return [...results].sort((a, b) => {
+      for (const [path, direction] of Object.entries(sortedList)) {
+        const aValue = this.getNestedValue(a, path)
+        const bValue = this.getNestedValue(b, path)
+
+        if (aValue < bValue) return -1 * direction
+        if (aValue > bValue) return 1 * direction
+      }
+      return 0
+    })
+  }
+
+  private filterFields(obj: any, select: string[]): any {
+    const result: any = Object.create(null)
+
+    select.forEach((field) => {
+      const parts = field.split('.')
+      this.setNestedValue(result, obj, parts)
+    })
+
+    return result
+  }
+
+  private setNestedValue(result: any, source: any, parts: string[]): void {
+    let currentResult = result
+    let currentSource = source
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]
+      const isLast = i === parts.length - 1
+
+      if (part.endsWith('[]')) {
+        const arrayField = part.slice(0, -2)
+        if (!Array.isArray(currentSource[arrayField])) {
+          return
+        }
+        if (!currentResult[arrayField]) {
+          currentResult[arrayField] = []
+        }
+        if (isLast) {
+          currentResult[arrayField] = currentSource[arrayField]
+        } else {
+          currentSource[arrayField].forEach((item: any, index: number) => {
+            if (!currentResult[arrayField][index]) {
+              currentResult[arrayField][index] = Object.create(null)
+            }
+            this.setNestedValue(currentResult[arrayField][index], item, parts.slice(i + 1))
+          })
+        }
+      } else {
+        if (isLast) {
+          if (currentSource[part] !== undefined) {
+            currentResult[part] = currentSource[part]
+          }
+        } else {
+          if (!currentSource[part]) {
+            return
+          }
+          if (!currentResult[part]) {
+            currentResult[part] = Array.isArray(currentSource[part]) ? [] : Object.create(null)
+          }
+          currentResult = currentResult[part]
+          currentSource = currentSource[part]
+        }
+      }
+    }
+  }
+}
+
+export interface QueryFilter {
+  typeName?: string
+  'value.id'?: UUID
+  filters?: any
+  [key: string]: any
+}

--- a/adapters/memory/read-model-store/test/expect.ts
+++ b/adapters/memory/read-model-store/test/expect.ts
@@ -1,0 +1,8 @@
+import * as chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { default as sinonChai } from 'sinon-chai'
+
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+
+export const expect = chai.expect

--- a/adapters/memory/read-model-store/test/memory-read-model-store.test.ts
+++ b/adapters/memory/read-model-store/test/memory-read-model-store.test.ts
@@ -1,0 +1,294 @@
+import { expect } from './expect'
+import { MemoryReadModelRegistry } from '../src/memory-read-model-registry'
+import { evaluateFilter } from '../src/library/filter-evaluator'
+import { ReadModelEnvelope, ReadModelInterface, OptimisticConcurrencyUnexpectedVersionError } from '@magek/common'
+import { faker } from '@faker-js/faker'
+
+describe('MemoryReadModelRegistry', () => {
+  let registry: MemoryReadModelRegistry
+
+  beforeEach(() => {
+    registry = new MemoryReadModelRegistry()
+  })
+
+  function createMockReadModel(overrides?: Partial<ReadModelInterface>): ReadModelInterface {
+    return {
+      id: faker.string.uuid(),
+      name: faker.person.fullName(),
+      email: faker.internet.email(),
+      age: faker.number.int({ min: 18, max: 80 }),
+      active: true,
+      magekMetadata: {
+        version: 1,
+        schemaVersion: 1,
+      },
+      ...overrides,
+    }
+  }
+
+  function createMockEnvelope(typeName: string, readModel: ReadModelInterface): ReadModelEnvelope {
+    return {
+      typeName,
+      value: readModel,
+    }
+  }
+
+  describe('store and query', () => {
+    it('should store and retrieve a read model', async () => {
+      const readModel = createMockReadModel()
+      const envelope = createMockEnvelope('User', readModel)
+
+      await registry.store(envelope, 0)
+
+      const results = await registry.query({ typeName: 'User', 'value.id': readModel.id })
+      expect(results).to.have.length(1)
+      expect(results[0].value.id).to.equal(readModel.id)
+    })
+
+    it('should update read model with optimistic concurrency', async () => {
+      const readModel = createMockReadModel()
+      const envelope = createMockEnvelope('User', readModel)
+
+      await registry.store(envelope, 0)
+
+      // Update with version 2
+      const updatedReadModel = { ...readModel, name: 'Updated Name', magekMetadata: { version: 2, schemaVersion: 1 } }
+      const updatedEnvelope = createMockEnvelope('User', updatedReadModel)
+
+      await registry.store(updatedEnvelope, 1)
+
+      const results = await registry.query({ typeName: 'User', 'value.id': readModel.id })
+      expect(results).to.have.length(1)
+      expect(results[0].value.name).to.equal('Updated Name')
+    })
+
+    it('should throw on optimistic concurrency conflict', async () => {
+      const readModel = createMockReadModel()
+      const envelope = createMockEnvelope('User', readModel)
+
+      await registry.store(envelope, 0)
+
+      // Try to update with wrong expected version
+      const updatedReadModel = { ...readModel, name: 'Updated Name', magekMetadata: { version: 2, schemaVersion: 1 } }
+      const updatedEnvelope = createMockEnvelope('User', updatedReadModel)
+
+      await expect(registry.store(updatedEnvelope, 5)).to.be.rejectedWith(OptimisticConcurrencyUnexpectedVersionError)
+    })
+
+    it('should filter by typeName', async () => {
+      const user = createMockReadModel()
+      const product = createMockReadModel()
+
+      await registry.store(createMockEnvelope('User', user), 0)
+      await registry.store(createMockEnvelope('Product', product), 0)
+
+      const results = await registry.query({ typeName: 'User' })
+      expect(results).to.have.length(1)
+      expect(results[0].typeName).to.equal('User')
+    })
+  })
+
+  describe('sorting', () => {
+    it('should sort results ascending', async () => {
+      const user1 = createMockReadModel({ name: 'Zebra' })
+      const user2 = createMockReadModel({ name: 'Alpha' })
+
+      await registry.store(createMockEnvelope('User', user1), 0)
+      await registry.store(createMockEnvelope('User', user2), 0)
+
+      const results = await registry.query({ typeName: 'User' }, { name: 'ASC' })
+      expect(results[0].value.name).to.equal('Alpha')
+      expect(results[1].value.name).to.equal('Zebra')
+    })
+
+    it('should sort results descending', async () => {
+      const user1 = createMockReadModel({ name: 'Alpha' })
+      const user2 = createMockReadModel({ name: 'Zebra' })
+
+      await registry.store(createMockEnvelope('User', user1), 0)
+      await registry.store(createMockEnvelope('User', user2), 0)
+
+      const results = await registry.query({ typeName: 'User' }, { name: 'DESC' })
+      expect(results[0].value.name).to.equal('Zebra')
+      expect(results[1].value.name).to.equal('Alpha')
+    })
+  })
+
+  describe('pagination', () => {
+    it('should apply limit', async () => {
+      for (let i = 0; i < 5; i++) {
+        await registry.store(createMockEnvelope('User', createMockReadModel()), 0)
+      }
+
+      const results = await registry.query({ typeName: 'User' }, undefined, 0, 2)
+      expect(results).to.have.length(2)
+    })
+
+    it('should apply skip', async () => {
+      for (let i = 0; i < 5; i++) {
+        await registry.store(createMockEnvelope('User', createMockReadModel({ name: `User${i}` })), 0)
+      }
+
+      const allResults = await registry.query({ typeName: 'User' }, { name: 'ASC' })
+      const skippedResults = await registry.query({ typeName: 'User' }, { name: 'ASC' }, 2)
+
+      expect(skippedResults).to.have.length(3)
+      expect(skippedResults[0].value.name).to.equal(allResults[2].value.name)
+    })
+  })
+
+  describe('field projection', () => {
+    it('should select only specified fields', async () => {
+      const user = createMockReadModel({ name: 'John', email: 'john@example.com', age: 30 })
+      await registry.store(createMockEnvelope('User', user), 0)
+
+      const results = await registry.query({ typeName: 'User' }, undefined, undefined, undefined, ['name', 'id'] as any)
+
+      expect(results[0].value).to.have.property('name')
+      expect(results[0].value).to.have.property('id')
+      expect(results[0].value).to.not.have.property('email')
+      expect(results[0].value).to.not.have.property('age')
+    })
+  })
+
+  describe('deleteById', () => {
+    it('should delete a read model', async () => {
+      const user = createMockReadModel()
+      await registry.store(createMockEnvelope('User', user), 0)
+
+      const count = await registry.deleteById(user.id, 'User')
+
+      expect(count).to.equal(1)
+      expect(registry.getCount()).to.equal(0)
+    })
+
+    it('should return 0 when read model not found', async () => {
+      const count = await registry.deleteById(faker.string.uuid(), 'User')
+      expect(count).to.equal(0)
+    })
+  })
+
+  describe('count', () => {
+    it('should count all read models', async () => {
+      await registry.store(createMockEnvelope('User', createMockReadModel()), 0)
+      await registry.store(createMockEnvelope('User', createMockReadModel()), 0)
+      await registry.store(createMockEnvelope('Product', createMockReadModel()), 0)
+
+      const count = await registry.count()
+      expect(count).to.equal(3)
+    })
+
+    it('should count filtered read models', async () => {
+      await registry.store(createMockEnvelope('User', createMockReadModel()), 0)
+      await registry.store(createMockEnvelope('User', createMockReadModel()), 0)
+      await registry.store(createMockEnvelope('Product', createMockReadModel()), 0)
+
+      const count = await registry.count({ typeName: 'User' })
+      expect(count).to.equal(2)
+    })
+  })
+})
+
+describe('evaluateFilter', () => {
+  describe('comparison operators', () => {
+    it('should evaluate eq filter', () => {
+      expect(evaluateFilter({ name: 'John' }, { name: { eq: 'John' } })).to.be.true
+      expect(evaluateFilter({ name: 'Jane' }, { name: { eq: 'John' } })).to.be.false
+    })
+
+    it('should evaluate ne filter', () => {
+      expect(evaluateFilter({ name: 'Jane' }, { name: { ne: 'John' } })).to.be.true
+      expect(evaluateFilter({ name: 'John' }, { name: { ne: 'John' } })).to.be.false
+    })
+
+    it('should evaluate lt filter', () => {
+      expect(evaluateFilter({ age: 20 }, { age: { lt: 30 } })).to.be.true
+      expect(evaluateFilter({ age: 30 }, { age: { lt: 30 } })).to.be.false
+    })
+
+    it('should evaluate gt filter', () => {
+      expect(evaluateFilter({ age: 40 }, { age: { gt: 30 } })).to.be.true
+      expect(evaluateFilter({ age: 30 }, { age: { gt: 30 } })).to.be.false
+    })
+
+    it('should evaluate lte filter', () => {
+      expect(evaluateFilter({ age: 30 }, { age: { lte: 30 } })).to.be.true
+      expect(evaluateFilter({ age: 31 }, { age: { lte: 30 } })).to.be.false
+    })
+
+    it('should evaluate gte filter', () => {
+      expect(evaluateFilter({ age: 30 }, { age: { gte: 30 } })).to.be.true
+      expect(evaluateFilter({ age: 29 }, { age: { gte: 30 } })).to.be.false
+    })
+  })
+
+  describe('collection operators', () => {
+    it('should evaluate in filter', () => {
+      expect(evaluateFilter({ status: 'active' }, { status: { in: ['active', 'pending'] } })).to.be.true
+      expect(evaluateFilter({ status: 'closed' }, { status: { in: ['active', 'pending'] } })).to.be.false
+    })
+  })
+
+  describe('existence operators', () => {
+    it('should evaluate isDefined filter', () => {
+      expect(evaluateFilter({ name: 'John' }, { name: { isDefined: true } })).to.be.true
+      expect(evaluateFilter({ name: undefined }, { name: { isDefined: true } })).to.be.false
+      expect(evaluateFilter({ name: undefined }, { name: { isDefined: false } })).to.be.true
+    })
+  })
+
+  describe('string operators', () => {
+    it('should evaluate contains filter', () => {
+      expect(evaluateFilter({ email: 'john@example.com' }, { email: { contains: 'example' } })).to.be.true
+      expect(evaluateFilter({ email: 'john@test.com' }, { email: { contains: 'example' } })).to.be.false
+    })
+
+    it('should evaluate beginsWith filter', () => {
+      expect(evaluateFilter({ name: 'John Doe' }, { name: { beginsWith: 'John' } })).to.be.true
+      expect(evaluateFilter({ name: 'Jane Doe' }, { name: { beginsWith: 'John' } })).to.be.false
+    })
+
+    it('should evaluate regex filter', () => {
+      expect(evaluateFilter({ email: 'john@example.com' }, { email: { regex: '^john@' } })).to.be.true
+      expect(evaluateFilter({ email: 'jane@example.com' }, { email: { regex: '^john@' } })).to.be.false
+    })
+
+    it('should evaluate iRegex filter (case insensitive)', () => {
+      expect(evaluateFilter({ name: 'JOHN' }, { name: { iRegex: 'john' } })).to.be.true
+    })
+  })
+
+  describe('array operators', () => {
+    it('should evaluate includes filter with string', () => {
+      expect(evaluateFilter({ tags: ['javascript', 'typescript'] }, { tags: { includes: 'script' } })).to.be.true
+    })
+  })
+
+  describe('logical operators', () => {
+    it('should evaluate and filter', () => {
+      const value = { name: 'John', age: 30 }
+      expect(evaluateFilter(value, { and: [{ name: { eq: 'John' } }, { age: { gte: 25 } }] })).to.be.true
+      expect(evaluateFilter(value, { and: [{ name: { eq: 'John' } }, { age: { gte: 35 } }] })).to.be.false
+    })
+
+    it('should evaluate or filter', () => {
+      const value = { name: 'John', age: 20 }
+      expect(evaluateFilter(value, { or: [{ name: { eq: 'Jane' } }, { age: { lt: 25 } }] })).to.be.true
+      expect(evaluateFilter(value, { or: [{ name: { eq: 'Jane' } }, { age: { gt: 25 } }] })).to.be.false
+    })
+
+    it('should evaluate not filter', () => {
+      const value = { status: 'active' }
+      expect(evaluateFilter(value, { not: { status: { eq: 'deleted' } } })).to.be.true
+      expect(evaluateFilter(value, { not: { status: { eq: 'active' } } })).to.be.false
+    })
+  })
+
+  describe('nested fields', () => {
+    it('should access nested field values', () => {
+      const value = { address: { city: 'New York', country: 'USA' } }
+      expect(evaluateFilter(value, { address: { city: { eq: 'New York' } } })).to.be.true
+      expect(evaluateFilter(value, { address: { city: { eq: 'Boston' } } })).to.be.false
+    })
+  })
+})

--- a/adapters/memory/read-model-store/tsconfig.eslint.json
+++ b/adapters/memory/read-model-store/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/adapters/memory/read-model-store/tsconfig.json
+++ b/adapters/memory/read-model-store/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/adapters/memory/read-model-store/tsconfig.test.json
+++ b/adapters/memory/read-model-store/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {"rootDir": "."},
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/adapters/memory/session-store/.mocharc.yml
+++ b/adapters/memory/session-store/.mocharc.yml
@@ -1,0 +1,11 @@
+diff: true
+require: tsx/cjs
+extension:
+  - ts
+package: './package.json'
+recursive: true
+reporter: 'spec'
+timeout: 5000
+full-trace: true
+bail: true
+color: true

--- a/adapters/memory/session-store/eslint.config.mjs
+++ b/adapters/memory/session-store/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.eslint.json'
+      }
+    }
+  }
+]

--- a/adapters/memory/session-store/package.json
+++ b/adapters/memory/session-store/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@magek/adapter-session-store-memory",
+  "version": "0.0.6",
+  "description": "In-memory session store adapter for the Magek framework",
+  "keywords": [
+    "session-store",
+    "memory",
+    "in-memory",
+    "websocket",
+    "connections",
+    "subscriptions"
+  ],
+  "author": "Boosterin Labs SLU",
+  "homepage": "https://magek.ai",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theam/magek.git"
+  },
+  "engines": {
+    "node": ">=22.0.0 <23.0.0"
+  },
+  "dependencies": {
+    "@magek/common": "workspace:^0.0.6",
+    "tslib": "2.8.1"
+  },
+  "scripts": {
+    "format": "prettier --write --ext '.js,.ts' **/*.ts **/*/*.ts",
+    "lint:check": "eslint \"**/*.ts\"",
+    "lint:fix": "eslint --quiet --fix \"**/*.ts\"",
+    "build": "tsc -b tsconfig.json",
+    "clean": "rimraf ./dist tsconfig.tsbuildinfo",
+    "prepack": "tsc -b tsconfig.json",
+    "test": "tsc --noEmit -p tsconfig.test.json && c8 mocha --forbid-only \"test/**/*.test.ts\""
+  },
+  "bugs": {
+    "url": "https://github.com/theam/magek/issues"
+  },
+  "devDependencies": {
+    "@magek/eslint-config": "workspace:^0.0.6",
+    "@types/chai": "5.2.3",
+    "@types/chai-as-promised": "8.0.2",
+    "@types/mocha": "10.0.10",
+    "@types/node": "22.19.7",
+    "@types/sinon": "21.0.0",
+    "@types/sinon-chai": "4.0.0",
+    "chai": "6.2.2",
+    "chai-as-promised": "8.0.2",
+    "@faker-js/faker": "10.2.0",
+    "mocha": "11.7.5",
+    "c8": "^10.1.3",
+    "rimraf": "6.1.2",
+    "sinon": "21.0.1",
+    "sinon-chai": "4.0.1",
+    "tsx": "^4.19.2",
+    "typescript": "5.9.3"
+  }
+}

--- a/adapters/memory/session-store/package.json
+++ b/adapters/memory/session-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magek/adapter-session-store-memory",
-  "version": "0.0.6",
+  "version": "0.0.10",
   "description": "In-memory session store adapter for the Magek framework",
   "keywords": [
     "session-store",
@@ -28,7 +28,7 @@
     "node": ">=22.0.0 <23.0.0"
   },
   "dependencies": {
-    "@magek/common": "workspace:^0.0.6",
+    "@magek/common": "workspace:^0.0.10",
     "tslib": "2.8.1"
   },
   "scripts": {
@@ -44,7 +44,7 @@
     "url": "https://github.com/theam/magek/issues"
   },
   "devDependencies": {
-    "@magek/eslint-config": "workspace:^0.0.6",
+    "@magek/eslint-config": "workspace:^0.0.10",
     "@types/chai": "5.2.3",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",

--- a/adapters/memory/session-store/package.json
+++ b/adapters/memory/session-store/package.json
@@ -48,7 +48,7 @@
     "@types/chai": "5.2.3",
     "@types/chai-as-promised": "8.0.2",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.19.7",
+    "@types/node": "22.19.8",
     "@types/sinon": "21.0.0",
     "@types/sinon-chai": "4.0.0",
     "chai": "6.2.2",

--- a/adapters/memory/session-store/src/index.ts
+++ b/adapters/memory/session-store/src/index.ts
@@ -1,0 +1,5 @@
+export { MemorySessionStoreAdapter } from './memory-session-store-adapter'
+
+// Export a default instance for easy usage
+import { MemorySessionStoreAdapter } from './memory-session-store-adapter'
+export const sessionStore = new MemorySessionStoreAdapter()

--- a/adapters/memory/session-store/src/memory-session-store-adapter.ts
+++ b/adapters/memory/session-store/src/memory-session-store-adapter.ts
@@ -1,0 +1,235 @@
+import { SessionStoreAdapter, MagekConfig, UUID, getLogger, SubscriptionEnvelope } from '@magek/common'
+
+export class MemorySessionStoreAdapter implements SessionStoreAdapter {
+  private connections: Map<UUID, Record<string, any>> = new Map()
+  private subscriptions: Map<UUID, Record<string, any>> = new Map()
+  private subscriptionsByConnection: Map<UUID, Set<UUID>> = new Map()
+  private subscriptionsByClassName: Map<string, Set<UUID>> = new Map()
+
+  async storeConnection(
+    config: MagekConfig,
+    connectionId: UUID,
+    connectionData: Record<string, any>
+  ): Promise<void> {
+    const logger = getLogger(config, 'MemorySessionStoreAdapter#storeConnection')
+    logger.debug('Storing connection data:', { connectionId, connectionData })
+
+    this.connections.set(connectionId, {
+      ...connectionData,
+      connectionID: connectionId,
+    })
+  }
+
+  async fetchConnection(
+    config: MagekConfig,
+    connectionId: UUID
+  ): Promise<Record<string, any> | undefined> {
+    const data = this.connections.get(connectionId)
+
+    if (!data) {
+      return undefined
+    }
+
+    // Remove internal fields before returning
+    const { connectionID, ...connectionData } = data
+    return connectionData
+  }
+
+  async deleteConnection(config: MagekConfig, connectionId: UUID): Promise<void> {
+    const logger = getLogger(config, 'MemorySessionStoreAdapter#deleteConnection')
+
+    if (!this.connections.has(connectionId)) {
+      logger.info(`No connections found with connectionID=${connectionId}`)
+      return
+    }
+
+    this.connections.delete(connectionId)
+    logger.debug('Deleted connection:', connectionId)
+  }
+
+  async storeSubscription(
+    config: MagekConfig,
+    connectionId: UUID,
+    subscriptionId: UUID,
+    subscriptionData: Record<string, any>
+  ): Promise<void> {
+    const logger = getLogger(config, 'MemorySessionStoreAdapter#storeSubscription')
+    logger.debug('Storing subscription data:', { connectionId, subscriptionId, subscriptionData })
+
+    const data = {
+      ...subscriptionData,
+      connectionID: connectionId,
+      subscriptionID: subscriptionId,
+    }
+
+    this.subscriptions.set(subscriptionId, data)
+
+    // Index by connection
+    if (!this.subscriptionsByConnection.has(connectionId)) {
+      this.subscriptionsByConnection.set(connectionId, new Set())
+    }
+    this.subscriptionsByConnection.get(connectionId)!.add(subscriptionId)
+
+    // Index by className if present
+    const className = subscriptionData.className
+    if (className) {
+      if (!this.subscriptionsByClassName.has(className)) {
+        this.subscriptionsByClassName.set(className, new Set())
+      }
+      this.subscriptionsByClassName.get(className)!.add(subscriptionId)
+    }
+  }
+
+  async fetchSubscription(
+    config: MagekConfig,
+    subscriptionId: UUID
+  ): Promise<Record<string, any> | undefined> {
+    const data = this.subscriptions.get(subscriptionId)
+
+    if (!data) {
+      return undefined
+    }
+
+    // Remove internal fields before returning
+    const { connectionID, subscriptionID, ...subscriptionData } = data
+    return subscriptionData
+  }
+
+  async deleteSubscription(config: MagekConfig, connectionId: UUID, subscriptionId: UUID): Promise<void> {
+    const logger = getLogger(config, 'MemorySessionStoreAdapter#deleteSubscription')
+
+    const data = this.subscriptions.get(subscriptionId)
+    if (!data) {
+      logger.info(`No subscription found with connectionID=${connectionId} and subscriptionID=${subscriptionId}`)
+      return
+    }
+
+    // Remove from className index
+    const className = data.className
+    if (className) {
+      this.subscriptionsByClassName.get(className)?.delete(subscriptionId)
+    }
+
+    // Remove from connection index
+    this.subscriptionsByConnection.get(connectionId)?.delete(subscriptionId)
+
+    // Remove subscription
+    this.subscriptions.delete(subscriptionId)
+
+    logger.debug('Deleted subscription:', { connectionId, subscriptionId })
+  }
+
+  async fetchSubscriptionsForConnection(
+    config: MagekConfig,
+    connectionId: UUID
+  ): Promise<Array<Record<string, any>>> {
+    const subscriptionIds = this.subscriptionsByConnection.get(connectionId)
+
+    if (!subscriptionIds) {
+      return []
+    }
+
+    const results: Array<Record<string, any>> = []
+    for (const subscriptionId of Array.from(subscriptionIds)) {
+      const data = this.subscriptions.get(subscriptionId)
+      if (data) {
+        const { connectionID, subscriptionID, ...subscriptionData } = data
+        results.push(subscriptionData)
+      }
+    }
+
+    return results
+  }
+
+  async fetchSubscriptionsByClassName(
+    config: MagekConfig,
+    className: string
+  ): Promise<Array<SubscriptionEnvelope>> {
+    const subscriptionIds = this.subscriptionsByClassName.get(className)
+
+    if (!subscriptionIds) {
+      return []
+    }
+
+    const results: Array<SubscriptionEnvelope> = []
+    for (const subscriptionId of Array.from(subscriptionIds)) {
+      const data = this.subscriptions.get(subscriptionId)
+      if (data) {
+        results.push(data as SubscriptionEnvelope)
+      }
+    }
+
+    return results
+  }
+
+  async deleteSubscriptionsForConnection(config: MagekConfig, connectionId: UUID): Promise<void> {
+    const logger = getLogger(config, 'MemorySessionStoreAdapter#deleteSubscriptionsForConnection')
+
+    const subscriptionIds = this.subscriptionsByConnection.get(connectionId)
+
+    if (!subscriptionIds || subscriptionIds.size === 0) {
+      logger.debug(`No subscriptions found for connection: ${connectionId}`)
+      return
+    }
+
+    let removed = 0
+    for (const subscriptionId of Array.from(subscriptionIds)) {
+      const data = this.subscriptions.get(subscriptionId)
+      if (data) {
+        // Remove from className index
+        const className = data.className
+        if (className) {
+          this.subscriptionsByClassName.get(className)?.delete(subscriptionId)
+        }
+
+        this.subscriptions.delete(subscriptionId)
+        removed++
+      }
+    }
+
+    // Clear the connection's subscription set
+    this.subscriptionsByConnection.delete(connectionId)
+
+    logger.debug(`Deleted ${removed} subscriptions for connection:`, connectionId)
+  }
+
+  healthCheck = {
+    isUp: async (config: MagekConfig): Promise<boolean> => {
+      // In-memory store is always up if the process is running
+      return true
+    },
+
+    details: async (config: MagekConfig): Promise<unknown> => {
+      return {
+        type: 'memory',
+        status: 'healthy',
+        connections: {
+          count: this.connections.size,
+        },
+        subscriptions: {
+          count: this.subscriptions.size,
+        },
+      }
+    },
+
+    urls: async (config: MagekConfig): Promise<Array<string>> => {
+      return ['memory://in-memory-session-store']
+    },
+  }
+
+  // Helper methods for testing
+  getConnectionsCount(): number {
+    return this.connections.size
+  }
+
+  getSubscriptionsCount(): number {
+    return this.subscriptions.size
+  }
+
+  clear(): void {
+    this.connections.clear()
+    this.subscriptions.clear()
+    this.subscriptionsByConnection.clear()
+    this.subscriptionsByClassName.clear()
+  }
+}

--- a/adapters/memory/session-store/test/expect.ts
+++ b/adapters/memory/session-store/test/expect.ts
@@ -1,0 +1,8 @@
+import * as chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { default as sinonChai } from 'sinon-chai'
+
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+
+export const expect = chai.expect

--- a/adapters/memory/session-store/test/memory-session-store.test.ts
+++ b/adapters/memory/session-store/test/memory-session-store.test.ts
@@ -1,0 +1,248 @@
+import { expect } from './expect'
+import { MemorySessionStoreAdapter } from '../src/memory-session-store-adapter'
+import { MagekConfig } from '@magek/common'
+import { faker } from '@faker-js/faker'
+import { fake, restore } from 'sinon'
+
+describe('MemorySessionStoreAdapter', () => {
+  let adapter: MemorySessionStoreAdapter
+  let mockConfig: MagekConfig
+
+  beforeEach(() => {
+    adapter = new MemorySessionStoreAdapter()
+    mockConfig = new MagekConfig('test')
+    mockConfig.appName = 'test-app'
+    mockConfig.logger = {
+      info: fake(),
+      warn: fake(),
+      error: fake(),
+      debug: fake(),
+    }
+  })
+
+  afterEach(() => {
+    restore()
+    adapter.clear()
+  })
+
+  describe('connections', () => {
+    describe('storeConnection', () => {
+      it('should store a connection', async () => {
+        const connectionId = faker.string.uuid()
+        const connectionData = { user: 'testUser', token: 'testToken' }
+
+        await adapter.storeConnection(mockConfig, connectionId, connectionData)
+
+        expect(adapter.getConnectionsCount()).to.equal(1)
+      })
+    })
+
+    describe('fetchConnection', () => {
+      it('should fetch a stored connection', async () => {
+        const connectionId = faker.string.uuid()
+        const connectionData = { user: 'testUser', token: 'testToken' }
+
+        await adapter.storeConnection(mockConfig, connectionId, connectionData)
+        const result = await adapter.fetchConnection(mockConfig, connectionId)
+
+        expect(result).to.deep.equal(connectionData)
+      })
+
+      it('should return undefined for non-existent connection', async () => {
+        const result = await adapter.fetchConnection(mockConfig, faker.string.uuid())
+
+        expect(result).to.be.undefined
+      })
+    })
+
+    describe('deleteConnection', () => {
+      it('should delete a stored connection', async () => {
+        const connectionId = faker.string.uuid()
+        const connectionData = { user: 'testUser' }
+
+        await adapter.storeConnection(mockConfig, connectionId, connectionData)
+        await adapter.deleteConnection(mockConfig, connectionId)
+
+        expect(adapter.getConnectionsCount()).to.equal(0)
+      })
+
+      it('should handle deleting non-existent connection gracefully', async () => {
+        await adapter.deleteConnection(mockConfig, faker.string.uuid())
+
+        expect(adapter.getConnectionsCount()).to.equal(0)
+      })
+    })
+  })
+
+  describe('subscriptions', () => {
+    describe('storeSubscription', () => {
+      it('should store a subscription', async () => {
+        const connectionId = faker.string.uuid()
+        const subscriptionId = faker.string.uuid()
+        const subscriptionData = { className: 'TestReadModel', filter: {} }
+
+        await adapter.storeSubscription(mockConfig, connectionId, subscriptionId, subscriptionData)
+
+        expect(adapter.getSubscriptionsCount()).to.equal(1)
+      })
+    })
+
+    describe('fetchSubscription', () => {
+      it('should fetch a stored subscription', async () => {
+        const connectionId = faker.string.uuid()
+        const subscriptionId = faker.string.uuid()
+        const subscriptionData = { className: 'TestReadModel', filter: { name: 'test' } }
+
+        await adapter.storeSubscription(mockConfig, connectionId, subscriptionId, subscriptionData)
+        const result = await adapter.fetchSubscription(mockConfig, subscriptionId)
+
+        expect(result).to.deep.equal(subscriptionData)
+      })
+
+      it('should return undefined for non-existent subscription', async () => {
+        const result = await adapter.fetchSubscription(mockConfig, faker.string.uuid())
+
+        expect(result).to.be.undefined
+      })
+    })
+
+    describe('deleteSubscription', () => {
+      it('should delete a stored subscription', async () => {
+        const connectionId = faker.string.uuid()
+        const subscriptionId = faker.string.uuid()
+        const subscriptionData = { className: 'TestReadModel' }
+
+        await adapter.storeSubscription(mockConfig, connectionId, subscriptionId, subscriptionData)
+        await adapter.deleteSubscription(mockConfig, connectionId, subscriptionId)
+
+        expect(adapter.getSubscriptionsCount()).to.equal(0)
+      })
+
+      it('should handle deleting non-existent subscription gracefully', async () => {
+        await adapter.deleteSubscription(mockConfig, faker.string.uuid(), faker.string.uuid())
+
+        expect(adapter.getSubscriptionsCount()).to.equal(0)
+      })
+    })
+
+    describe('fetchSubscriptionsForConnection', () => {
+      it('should fetch all subscriptions for a connection', async () => {
+        const connectionId = faker.string.uuid()
+
+        await adapter.storeSubscription(mockConfig, connectionId, faker.string.uuid(), {
+          className: 'Model1',
+        })
+        await adapter.storeSubscription(mockConfig, connectionId, faker.string.uuid(), {
+          className: 'Model2',
+        })
+        await adapter.storeSubscription(mockConfig, faker.string.uuid(), faker.string.uuid(), {
+          className: 'Model3',
+        })
+
+        const results = await adapter.fetchSubscriptionsForConnection(mockConfig, connectionId)
+
+        expect(results).to.have.length(2)
+      })
+
+      it('should return empty array for connection with no subscriptions', async () => {
+        const results = await adapter.fetchSubscriptionsForConnection(mockConfig, faker.string.uuid())
+
+        expect(results).to.be.an('array').that.is.empty
+      })
+    })
+
+    describe('fetchSubscriptionsByClassName', () => {
+      it('should fetch all subscriptions for a class name', async () => {
+        const className = 'TestReadModel'
+
+        await adapter.storeSubscription(mockConfig, faker.string.uuid(), faker.string.uuid(), {
+          className,
+        })
+        await adapter.storeSubscription(mockConfig, faker.string.uuid(), faker.string.uuid(), {
+          className,
+        })
+        await adapter.storeSubscription(mockConfig, faker.string.uuid(), faker.string.uuid(), {
+          className: 'OtherModel',
+        })
+
+        const results = await adapter.fetchSubscriptionsByClassName(mockConfig, className)
+
+        expect(results).to.have.length(2)
+        results.forEach((result) => {
+          expect(result.className).to.equal(className)
+        })
+      })
+
+      it('should return empty array for class name with no subscriptions', async () => {
+        const results = await adapter.fetchSubscriptionsByClassName(mockConfig, 'NonExistent')
+
+        expect(results).to.be.an('array').that.is.empty
+      })
+    })
+
+    describe('deleteSubscriptionsForConnection', () => {
+      it('should delete all subscriptions for a connection', async () => {
+        const connectionId = faker.string.uuid()
+
+        await adapter.storeSubscription(mockConfig, connectionId, faker.string.uuid(), {
+          className: 'Model1',
+        })
+        await adapter.storeSubscription(mockConfig, connectionId, faker.string.uuid(), {
+          className: 'Model2',
+        })
+
+        await adapter.deleteSubscriptionsForConnection(mockConfig, connectionId)
+
+        expect(adapter.getSubscriptionsCount()).to.equal(0)
+      })
+
+      it('should not affect other connections subscriptions', async () => {
+        const connectionId1 = faker.string.uuid()
+        const connectionId2 = faker.string.uuid()
+
+        await adapter.storeSubscription(mockConfig, connectionId1, faker.string.uuid(), {
+          className: 'Model1',
+        })
+        await adapter.storeSubscription(mockConfig, connectionId2, faker.string.uuid(), {
+          className: 'Model2',
+        })
+
+        await adapter.deleteSubscriptionsForConnection(mockConfig, connectionId1)
+
+        expect(adapter.getSubscriptionsCount()).to.equal(1)
+      })
+    })
+  })
+
+  describe('healthCheck', () => {
+    describe('isUp', () => {
+      it('should return true', async () => {
+        const result = await adapter.healthCheck.isUp(mockConfig)
+
+        expect(result).to.be.true
+      })
+    })
+
+    describe('details', () => {
+      it('should return status and counts', async () => {
+        await adapter.storeConnection(mockConfig, faker.string.uuid(), {})
+        await adapter.storeSubscription(mockConfig, faker.string.uuid(), faker.string.uuid(), {})
+
+        const result = (await adapter.healthCheck.details(mockConfig)) as any
+
+        expect(result.type).to.equal('memory')
+        expect(result.status).to.equal('healthy')
+        expect(result.connections.count).to.equal(1)
+        expect(result.subscriptions.count).to.equal(1)
+      })
+    })
+
+    describe('urls', () => {
+      it('should return memory URL', async () => {
+        const result = await adapter.healthCheck.urls(mockConfig)
+
+        expect(result).to.deep.equal(['memory://in-memory-session-store'])
+      })
+    })
+  })
+})

--- a/adapters/memory/session-store/tsconfig.eslint.json
+++ b/adapters/memory/session-store/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/adapters/memory/session-store/tsconfig.json
+++ b/adapters/memory/session-store/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/adapters/memory/session-store/tsconfig.test.json
+++ b/adapters/memory/session-store/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {"rootDir": "."},
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/common/changes/@magek/adapter-event-store-memory/document-adapters-creation_2026-01-30-23-18.json
+++ b/common/changes/@magek/adapter-event-store-memory/document-adapters-creation_2026-01-30-23-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add in-memory adapter packages for event store, read model store, and session store",
+      "type": "none",
+      "packageName": "@magek/adapter-event-store-memory"
+    }
+  ],
+  "packageName": "@magek/adapter-event-store-memory",
+  "email": "github-actions[bot]@users.noreply.github.com"
+}

--- a/common/changes/@magek/adapter-read-model-store-memory/document-adapters-creation_2026-01-30-23-18.json
+++ b/common/changes/@magek/adapter-read-model-store-memory/document-adapters-creation_2026-01-30-23-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add in-memory adapter packages for event store, read model store, and session store",
+      "type": "none",
+      "packageName": "@magek/adapter-read-model-store-memory"
+    }
+  ],
+  "packageName": "@magek/adapter-read-model-store-memory",
+  "email": "github-actions[bot]@users.noreply.github.com"
+}

--- a/common/changes/@magek/adapter-session-store-memory/document-adapters-creation_2026-01-30-23-18.json
+++ b/common/changes/@magek/adapter-session-store-memory/document-adapters-creation_2026-01-30-23-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add in-memory adapter packages for event store, read model store, and session store",
+      "type": "none",
+      "packageName": "@magek/adapter-session-store-memory"
+    }
+  ],
+  "packageName": "@magek/adapter-session-store-memory",
+  "email": "github-actions[bot]@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -10,6 +10,189 @@ importers:
 
   .: {}
 
+  ../../adapters/memory/event-store:
+    dependencies:
+      '@magek/common':
+        specifier: workspace:^0.0.6
+        version: link:../../../packages/common
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+    devDependencies:
+      '@faker-js/faker':
+        specifier: 10.2.0
+        version: 10.2.0
+      '@magek/eslint-config':
+        specifier: workspace:^0.0.6
+        version: link:../../../tools/eslint-config
+      '@types/chai':
+        specifier: 5.2.3
+        version: 5.2.3
+      '@types/chai-as-promised':
+        specifier: 8.0.2
+        version: 8.0.2
+      '@types/mocha':
+        specifier: 10.0.10
+        version: 10.0.10
+      '@types/node':
+        specifier: 22.19.7
+        version: 22.19.7
+      '@types/sinon':
+        specifier: 21.0.0
+        version: 21.0.0
+      '@types/sinon-chai':
+        specifier: 4.0.0
+        version: 4.0.0
+      c8:
+        specifier: ^10.1.3
+        version: 10.1.3
+      chai:
+        specifier: 6.2.2
+        version: 6.2.2
+      chai-as-promised:
+        specifier: 8.0.2
+        version: 8.0.2(chai@6.2.2)
+      mocha:
+        specifier: 11.7.5
+        version: 11.7.5
+      rimraf:
+        specifier: 6.1.2
+        version: 6.1.2
+      sinon:
+        specifier: 21.0.1
+        version: 21.0.1
+      sinon-chai:
+        specifier: 4.0.1
+        version: 4.0.1(chai@6.2.2)(sinon@21.0.1)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+  ../../adapters/memory/read-model-store:
+    dependencies:
+      '@magek/common':
+        specifier: workspace:^0.0.6
+        version: link:../../../packages/common
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+    devDependencies:
+      '@faker-js/faker':
+        specifier: 10.2.0
+        version: 10.2.0
+      '@magek/eslint-config':
+        specifier: workspace:^0.0.6
+        version: link:../../../tools/eslint-config
+      '@types/chai':
+        specifier: 5.2.3
+        version: 5.2.3
+      '@types/chai-as-promised':
+        specifier: 8.0.2
+        version: 8.0.2
+      '@types/mocha':
+        specifier: 10.0.10
+        version: 10.0.10
+      '@types/node':
+        specifier: 22.19.7
+        version: 22.19.7
+      '@types/sinon':
+        specifier: 21.0.0
+        version: 21.0.0
+      '@types/sinon-chai':
+        specifier: 4.0.0
+        version: 4.0.0
+      c8:
+        specifier: ^10.1.3
+        version: 10.1.3
+      chai:
+        specifier: 6.2.2
+        version: 6.2.2
+      chai-as-promised:
+        specifier: 8.0.2
+        version: 8.0.2(chai@6.2.2)
+      mocha:
+        specifier: 11.7.5
+        version: 11.7.5
+      rimraf:
+        specifier: 6.1.2
+        version: 6.1.2
+      sinon:
+        specifier: 21.0.1
+        version: 21.0.1
+      sinon-chai:
+        specifier: 4.0.1
+        version: 4.0.1(chai@6.2.2)(sinon@21.0.1)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+  ../../adapters/memory/session-store:
+    dependencies:
+      '@magek/common':
+        specifier: workspace:^0.0.6
+        version: link:../../../packages/common
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
+    devDependencies:
+      '@faker-js/faker':
+        specifier: 10.2.0
+        version: 10.2.0
+      '@magek/eslint-config':
+        specifier: workspace:^0.0.6
+        version: link:../../../tools/eslint-config
+      '@types/chai':
+        specifier: 5.2.3
+        version: 5.2.3
+      '@types/chai-as-promised':
+        specifier: 8.0.2
+        version: 8.0.2
+      '@types/mocha':
+        specifier: 10.0.10
+        version: 10.0.10
+      '@types/node':
+        specifier: 22.19.7
+        version: 22.19.7
+      '@types/sinon':
+        specifier: 21.0.0
+        version: 21.0.0
+      '@types/sinon-chai':
+        specifier: 4.0.0
+        version: 4.0.0
+      c8:
+        specifier: ^10.1.3
+        version: 10.1.3
+      chai:
+        specifier: 6.2.2
+        version: 6.2.2
+      chai-as-promised:
+        specifier: 8.0.2
+        version: 8.0.2(chai@6.2.2)
+      mocha:
+        specifier: 11.7.5
+        version: 11.7.5
+      rimraf:
+        specifier: 6.1.2
+        version: 6.1.2
+      sinon:
+        specifier: 21.0.1
+        version: 21.0.1
+      sinon-chai:
+        specifier: 4.0.1
+        version: 4.0.1(chai@6.2.2)(sinon@21.0.1)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   ../../adapters/nedb/event-store:
     dependencies:
       '@magek/common':

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.19.7
-        version: 22.19.7
+        specifier: 22.19.8
+        version: 22.19.8
       '@types/sinon':
         specifier: 21.0.0
         version: 21.0.0
@@ -96,8 +96,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.19.7
-        version: 22.19.7
+        specifier: 22.19.8
+        version: 22.19.8
       '@types/sinon':
         specifier: 21.0.0
         version: 21.0.0
@@ -157,8 +157,8 @@ importers:
         specifier: 10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: 22.19.7
-        version: 22.19.7
+        specifier: 22.19.8
+        version: 22.19.8
       '@types/sinon':
         specifier: 21.0.0
         version: 21.0.0
@@ -446,8 +446,8 @@ importers:
         specifier: 4.2.0
         version: 4.2.0
       ora:
-        specifier: 9.1.0
-        version: 9.1.0
+        specifier: 9.2.0
+        version: 9.2.0
       ts-morph:
         specifier: 27.0.2
         version: 27.0.2
@@ -3370,8 +3370,8 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
-  ora@9.1.0:
-    resolution: {integrity: sha512-53uuLsXHOAJl5zLrUrzY9/kE+uIFEx7iaH4g2BIJQK4LZjY4LpCCYZVKDWIkL+F01wAaCg93duQ1whnK/AmY1A==}
+  ora@9.2.0:
+    resolution: {integrity: sha512-4sGT6oNDbqIuciDfD2aCkoPgHLmOe+g+xpFK2WDO0aQuD/bNHNwfdFosWP+DXmcxRyXeF8vnki6kXnOOHTuRSA==}
     engines: {node: '>=20'}
 
   outvariant@1.4.3:
@@ -3812,8 +3812,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  stdin-discarder@0.2.2:
-    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+  stdin-discarder@0.3.1:
+    resolution: {integrity: sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==}
     engines: {node: '>=18'}
 
   stop-iteration-iterator@1.1.0:
@@ -6839,7 +6839,7 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  ora@9.1.0:
+  ora@9.2.0:
     dependencies:
       chalk: 5.6.2
       cli-cursor: 5.0.0
@@ -6847,7 +6847,7 @@ snapshots:
       is-interactive: 2.0.0
       is-unicode-supported: 2.1.0
       log-symbols: 7.0.1
-      stdin-discarder: 0.2.2
+      stdin-discarder: 0.3.1
       string-width: 8.1.0
 
   outvariant@1.4.3: {}
@@ -7309,7 +7309,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  stdin-discarder@0.2.2: {}
+  stdin-discarder@0.3.1: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
   ../../adapters/memory/event-store:
     dependencies:
       '@magek/common':
-        specifier: workspace:^0.0.6
+        specifier: workspace:^0.0.10
         version: link:../../../packages/common
       tslib:
         specifier: 2.8.1
@@ -23,7 +23,7 @@ importers:
         specifier: 10.2.0
         version: 10.2.0
       '@magek/eslint-config':
-        specifier: workspace:^0.0.6
+        specifier: workspace:^0.0.10
         version: link:../../../tools/eslint-config
       '@types/chai':
         specifier: 5.2.3
@@ -74,7 +74,7 @@ importers:
   ../../adapters/memory/read-model-store:
     dependencies:
       '@magek/common':
-        specifier: workspace:^0.0.6
+        specifier: workspace:^0.0.10
         version: link:../../../packages/common
       tslib:
         specifier: 2.8.1
@@ -84,7 +84,7 @@ importers:
         specifier: 10.2.0
         version: 10.2.0
       '@magek/eslint-config':
-        specifier: workspace:^0.0.6
+        specifier: workspace:^0.0.10
         version: link:../../../tools/eslint-config
       '@types/chai':
         specifier: 5.2.3
@@ -135,7 +135,7 @@ importers:
   ../../adapters/memory/session-store:
     dependencies:
       '@magek/common':
-        specifier: workspace:^0.0.6
+        specifier: workspace:^0.0.10
         version: link:../../../packages/common
       tslib:
         specifier: 2.8.1
@@ -145,7 +145,7 @@ importers:
         specifier: 10.2.0
         version: 10.2.0
       '@magek/eslint-config':
-        specifier: workspace:^0.0.6
+        specifier: workspace:^0.0.10
         version: link:../../../tools/eslint-config
       '@types/chai':
         specifier: 5.2.3

--- a/docs/content/advanced/custom-adapters.md
+++ b/docs/content/advanced/custom-adapters.md
@@ -1,0 +1,324 @@
+# Custom Adapters
+
+Magek uses an adapter pattern to abstract away database and storage implementation details. This allows you to use different storage backends without modifying your application code. This guide explains how to create custom adapters for the Magek framework.
+
+## Overview
+
+Magek has three types of adapters:
+
+1. **Event Store Adapter** - Stores events and entity snapshots for event sourcing
+2. **Read Model Store Adapter** - Stores and queries read model projections
+3. **Session Store Adapter** - Manages WebSocket connections and GraphQL subscriptions
+
+Each adapter type has a well-defined interface that you must implement. The framework provides built-in adapters for NeDB (file-based) and in-memory storage.
+
+## Adapter Interfaces
+
+### Event Store Adapter
+
+The `EventStoreAdapter` interface (defined in `@magek/common`) handles event sourcing operations:
+
+```typescript
+interface EventStoreAdapter {
+  // Convert raw data to EventEnvelope objects
+  rawToEnvelopes(rawEvents: unknown): Array<EventEnvelope>
+
+  // Streaming methods (optional - can throw "not implemented")
+  rawStreamToEnvelopes(config: MagekConfig, context: unknown, dedupEventStream: EventStream): Array<EventEnvelope>
+  dedupEventStream(config: MagekConfig, rawEvents: unknown): Promise<EventStream>
+  produce(entityName: string, entityID: UUID, eventEnvelopes: Array<EventEnvelope>, config: MagekConfig): Promise<void>
+
+  // Core event operations
+  forEntitySince(config: MagekConfig, entityTypeName: string, entityID: UUID, since?: string): Promise<Array<EventEnvelope>>
+  latestEntitySnapshot(config: MagekConfig, entityTypeName: string, entityID: UUID): Promise<EntitySnapshotEnvelope | undefined>
+  store(eventEnvelopes: Array<NonPersistedEventEnvelope>, config: MagekConfig): Promise<Array<EventEnvelope>>
+  storeSnapshot(snapshotEnvelope: NonPersistedEntitySnapshotEnvelope, config: MagekConfig): Promise<EntitySnapshotEnvelope>
+
+  // Search and pagination
+  search(config: MagekConfig, parameters: EventSearchParameters): Promise<Array<EventSearchResponse>>
+  searchEntitiesIDs(config: MagekConfig, limit: number, afterCursor: Record<string, string> | undefined, entityTypeName: string): Promise<PaginatedEntitiesIdsResult>
+
+  // Dispatch tracking
+  storeDispatched(eventEnvelope: EventEnvelope, config: MagekConfig): Promise<boolean>
+
+  // Deletion operations
+  findDeletableEvent(config: MagekConfig, parameters: EventDeleteParameters): Promise<Array<EventEnvelopeFromDatabase>>
+  findDeletableSnapshot(config: MagekConfig, parameters: SnapshotDeleteParameters): Promise<Array<EntitySnapshotEnvelopeFromDatabase>>
+  deleteEvent(config: MagekConfig, events: Array<EventEnvelopeFromDatabase>): Promise<void>
+  deleteSnapshot(config: MagekConfig, snapshots: Array<EntitySnapshotEnvelopeFromDatabase>): Promise<void>
+
+  // Health check (optional)
+  healthCheck?: {
+    isUp(config: MagekConfig): Promise<boolean>
+    details(config: MagekConfig): Promise<unknown>
+    urls(config: MagekConfig): Promise<Array<string>>
+  }
+}
+```
+
+### Read Model Store Adapter
+
+The `ReadModelStoreAdapter` interface handles read model projections:
+
+```typescript
+interface ReadModelStoreAdapter {
+  // Fetch a specific read model by ID
+  fetch<TReadModel extends ReadModelInterface>(
+    config: MagekConfig,
+    readModelName: string,
+    readModelID: UUID,
+    sequenceKey?: SequenceKey
+  ): Promise<ReadOnlyNonEmptyArray<TReadModel> | undefined>
+
+  // Search read models with filters, sorting, and pagination
+  search<TReadModel extends ReadModelInterface>(
+    config: MagekConfig,
+    readModelName: string,
+    filters: FilterFor<unknown>,
+    sortBy?: SortFor<unknown>,
+    limit?: number,
+    afterCursor?: unknown,
+    paginatedVersion?: boolean,
+    select?: ProjectionFor<TReadModel>
+  ): Promise<Array<TReadModel> | ReadModelListResult<TReadModel>>
+
+  // Store or update a read model
+  store<TReadModel extends ReadModelInterface>(
+    config: MagekConfig,
+    readModelName: string,
+    readModel: ReadModelStoreEnvelope<TReadModel>
+  ): Promise<ReadModelStoreEnvelope<TReadModel>>
+
+  // Delete a read model
+  delete(config: MagekConfig, readModelName: string, readModelID: UUID): Promise<void>
+
+  // Convert raw data to envelopes
+  rawToEnvelopes<TReadModel extends ReadModelInterface>(
+    config: MagekConfig,
+    rawReadModels: unknown
+  ): Promise<Array<ReadModelStoreEnvelope<TReadModel>>>
+
+  // Health check (optional)
+  healthCheck?: {
+    isUp(config: MagekConfig): Promise<boolean>
+    details(config: MagekConfig): Promise<unknown>
+    urls(config: MagekConfig): Promise<Array<string>>
+  }
+}
+```
+
+### Session Store Adapter
+
+The `SessionStoreAdapter` interface manages real-time connections:
+
+```typescript
+interface SessionStoreAdapter {
+  // Connection management
+  storeConnection(config: MagekConfig, connectionId: UUID, connectionData: Record<string, any>): Promise<void>
+  fetchConnection(config: MagekConfig, connectionId: UUID): Promise<Record<string, any> | undefined>
+  deleteConnection(config: MagekConfig, connectionId: UUID): Promise<void>
+
+  // Subscription management
+  storeSubscription(config: MagekConfig, connectionId: UUID, subscriptionId: UUID, subscriptionData: Record<string, any>): Promise<void>
+  fetchSubscription(config: MagekConfig, subscriptionId: UUID): Promise<Record<string, any> | undefined>
+  deleteSubscription(config: MagekConfig, connectionId: UUID, subscriptionId: UUID): Promise<void>
+
+  // Bulk operations
+  fetchSubscriptionsForConnection(config: MagekConfig, connectionId: UUID): Promise<Array<Record<string, any>>>
+  deleteSubscriptionsForConnection(config: MagekConfig, connectionId: UUID): Promise<void>
+  fetchSubscriptionsByClassName(config: MagekConfig, className: string): Promise<Array<SubscriptionEnvelope>>
+
+  // Health check (optional)
+  healthCheck?: {
+    isUp(config: MagekConfig): Promise<boolean>
+    details(config: MagekConfig): Promise<unknown>
+    urls(config: MagekConfig): Promise<Array<string>>
+  }
+}
+```
+
+## Implementation Guide
+
+### Package Structure
+
+Create your adapter package with this structure:
+
+```
+adapters/<database>/<adapter-type>/
+├── src/
+│   ├── index.ts              # Export adapter singleton
+│   └── <database>-<type>.ts  # Implementation
+├── test/
+│   ├── expect.ts             # Test utilities
+│   └── <adapter>.test.ts     # Tests
+├── package.json
+├── tsconfig.json
+├── tsconfig.test.json
+├── tsconfig.eslint.json
+├── eslint.config.mjs
+└── .mocharc.yml
+```
+
+### Package Naming Convention
+
+Use this naming pattern: `@magek/adapter-{type}-{database}`
+
+Examples:
+- `@magek/adapter-event-store-nedb`
+- `@magek/adapter-read-model-store-memory`
+- `@magek/adapter-session-store-redis`
+
+### Implementing the Event Store
+
+Key implementation considerations:
+
+1. **Event Storage**: Store events with `kind: 'event'` and snapshots with `kind: 'snapshot'`
+2. **Timestamps**: Generate `createdAt` when storing events
+3. **Soft Deletes**: Events should be soft-deleted by setting `deletedAt` and clearing `value`
+4. **Snapshots**: Hard delete snapshots when requested
+5. **Dispatch Tracking**: Track which events have been dispatched to prevent duplicate processing
+
+Example implementation pattern:
+
+```typescript
+import { EventStoreAdapter } from '@magek/common'
+
+const eventRegistry = new YourEventRegistry()
+
+export const eventStore: EventStoreAdapter = {
+  rawToEnvelopes: (rawEvents) => rawEvents as Array<EventEnvelope>,
+
+  forEntitySince: async (config, entityTypeName, entityID, since) => {
+    const query = {
+      entityTypeName,
+      entityID,
+      kind: 'event',
+      createdAt: { $gt: since || new Date(0).toISOString() },
+      deletedAt: { $exists: false },
+    }
+    return eventRegistry.query(query)
+  },
+
+  store: async (eventEnvelopes, config) => {
+    const persisted = []
+    for (const envelope of eventEnvelopes) {
+      const withTimestamp = { ...envelope, createdAt: new Date().toISOString() }
+      await eventRegistry.store(withTimestamp)
+      persisted.push(withTimestamp)
+    }
+    return persisted
+  },
+
+  // ... implement other methods
+}
+```
+
+### Implementing the Read Model Store
+
+Key implementation considerations:
+
+1. **Optimistic Concurrency**: Check version before updates, throw `OptimisticConcurrencyUnexpectedVersionError` on conflicts
+2. **Filter Support**: Implement filtering operations (eq, ne, lt, gt, lte, gte, in, contains, etc.)
+3. **Sorting**: Support multi-field sorting with ASC/DESC
+4. **Pagination**: Implement cursor-based pagination
+5. **Field Projection**: Support selecting specific fields
+
+Filter operations to support:
+
+| Operation | Description | Example |
+|-----------|-------------|---------|
+| `eq` | Equals | `{ name: { eq: 'John' } }` |
+| `ne` | Not equals | `{ status: { ne: 'deleted' } }` |
+| `lt` | Less than | `{ age: { lt: 18 } }` |
+| `gt` | Greater than | `{ price: { gt: 100 } }` |
+| `lte` | Less than or equal | `{ age: { lte: 65 } }` |
+| `gte` | Greater than or equal | `{ rating: { gte: 4 } }` |
+| `in` | In array | `{ status: { in: ['active', 'pending'] } }` |
+| `isDefined` | Field exists | `{ email: { isDefined: true } }` |
+| `contains` | String contains | `{ name: { contains: 'smith' } }` |
+| `beginsWith` | String starts with | `{ name: { beginsWith: 'Dr.' } }` |
+| `regex` | Regular expression | `{ email: { regex: '@example.com$' } }` |
+| `iRegex` | Case-insensitive regex | `{ name: { iRegex: 'john' } }` |
+| `includes` | Array includes | `{ tags: { includes: 'featured' } }` |
+| `and` | Logical AND | `{ and: [filter1, filter2] }` |
+| `or` | Logical OR | `{ or: [filter1, filter2] }` |
+| `not` | Logical NOT | `{ not: { status: { eq: 'deleted' } } }` |
+
+### Implementing the Session Store
+
+Key implementation considerations:
+
+1. **Connection Indexing**: Index connections by ID for fast lookup
+2. **Subscription Indexing**: Index subscriptions by connection ID and class name
+3. **Cleanup**: Ensure deleting a connection also cleans up its subscriptions
+4. **Class Name Queries**: Support fetching subscriptions by read model class name
+
+### Health Checks
+
+Implement health checks to support monitoring:
+
+```typescript
+healthCheck: {
+  isUp: async (config) => {
+    try {
+      // Test database connectivity
+      await database.ping()
+      return true
+    } catch {
+      return false
+    }
+  },
+
+  details: async (config) => ({
+    type: 'your-database',
+    status: 'healthy',
+    eventsCount: await database.count('events'),
+  }),
+
+  urls: async (config) => ['your-database://connection-string'],
+}
+```
+
+## Configuration
+
+To use your custom adapter, configure it in your Magek application:
+
+```typescript
+import { MagekConfig } from '@magek/core'
+import { eventStore } from '@magek/adapter-event-store-your-db'
+import { readModelStore } from '@magek/adapter-read-model-store-your-db'
+import { sessionStore } from '@magek/adapter-session-store-your-db'
+
+const config = new MagekConfig('production')
+
+// Set custom adapters
+;(config as any).eventStoreAdapter = eventStore
+;(config as any).readModelStoreAdapter = readModelStore
+;(config as any).sessionStoreAdapter = sessionStore
+```
+
+## Best Practices
+
+1. **Export Singleton Instances**: Export pre-configured adapter instances for easy usage:
+   ```typescript
+   export const eventStore: EventStoreAdapter = { /* ... */ }
+   ```
+
+2. **Use Logging**: Use `getLogger(config, 'AdapterName#methodName')` for consistent logging
+
+3. **Handle Errors Gracefully**: Wrap database errors in appropriate Magek error types
+
+4. **Support TypeScript**: Export types and use generics where appropriate
+
+5. **Write Comprehensive Tests**: Test all interface methods including edge cases
+
+6. **Document Connection Requirements**: Clearly document any environment variables or configuration needed
+
+## Example Adapters
+
+For reference implementations, see:
+
+- **NeDB Adapters** (file-based): `adapters/nedb/`
+- **Memory Adapters** (in-memory): `adapters/memory/`
+
+These implementations demonstrate all required patterns and can serve as templates for your custom adapters.

--- a/docs/content/advanced/custom-adapters.md
+++ b/docs/content/advanced/custom-adapters.md
@@ -53,6 +53,10 @@ interface EventStoreAdapter {
     details(config: MagekConfig): Promise<unknown>
     urls(config: MagekConfig): Promise<Array<string>>
   }
+
+  // Async event processing (optional)
+  fetchUnprocessedEvents?(config: MagekConfig): Promise<Array<EventEnvelope>>
+  markEventProcessed?(config: MagekConfig, eventId: UUID): Promise<void>
 }
 ```
 
@@ -177,6 +181,7 @@ Key implementation considerations:
 3. **Soft Deletes**: Events should be soft-deleted by setting `deletedAt` and clearing `value`
 4. **Snapshots**: Hard delete snapshots when requested
 5. **Dispatch Tracking**: Track which events have been dispatched to prevent duplicate processing
+6. **Async Processing** (optional): Implement `fetchUnprocessedEvents` and `markEventProcessed` for polling-based event dispatch
 
 Example implementation pattern:
 
@@ -278,6 +283,48 @@ healthCheck: {
   urls: async (config) => ['your-database://connection-string'],
 }
 ```
+
+### Async Event Processing (Optional)
+
+Magek supports async event processing through polling. When implemented, the server polls for unprocessed events and dispatches them in batches, preventing duplicate processing.
+
+#### Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `eventPollingIntervalMs` | 1000 | Milliseconds between polling cycles |
+| `eventProcessingBatchSize` | 100 | Maximum events per batch |
+
+#### Implementation Pattern
+
+```typescript
+// Track cursor position
+let processingCursor: string = new Date(0).toISOString()
+
+async function fetchUnprocessedEvents(config: MagekConfig): Promise<Array<EventEnvelope>> {
+  const query = {
+    kind: 'event',
+    deletedAt: { $exists: false },
+    processedAt: { $exists: false },
+    createdAt: { $gt: processingCursor },
+  }
+  return database.query(query, { sort: 'createdAt', limit: config.eventProcessingBatchSize })
+}
+
+async function markEventProcessed(config: MagekConfig, eventId: UUID): Promise<void> {
+  const event = await database.findById(eventId)
+  if (!event) return
+  await database.update(eventId, { processedAt: new Date().toISOString() })
+  processingCursor = event.createdAt
+}
+```
+
+#### Important Considerations
+
+1. **Remove Synchronous Dispatch**: When implementing async processing, remove any `eventDispatcher()` call from your `store()` method
+2. **Cursor Persistence**: Persistent adapters should persist the cursor; in-memory can use a variable
+3. **Event Ordering**: Process events in `createdAt` order for consistency
+4. **Optional Implementation**: If not implemented, the server uses synchronous dispatch
 
 ## Configuration
 

--- a/rush.json
+++ b/rush.json
@@ -438,6 +438,24 @@
       "shouldPublish": true,
       "versionPolicyName": "magek",
       "projectFolder": "packages/mcp-server"
+    },
+    {
+      "packageName": "@magek/adapter-event-store-memory",
+      "shouldPublish": true,
+      "versionPolicyName": "magek",
+      "projectFolder": "adapters/memory/event-store"
+    },
+    {
+      "packageName": "@magek/adapter-read-model-store-memory",
+      "shouldPublish": true,
+      "versionPolicyName": "magek",
+      "projectFolder": "adapters/memory/read-model-store"
+    },
+    {
+      "packageName": "@magek/adapter-session-store-memory",
+      "shouldPublish": true,
+      "versionPolicyName": "magek",
+      "projectFolder": "adapters/memory/session-store"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add three new in-memory adapter packages for ephemeral/testing scenarios:
  - `@magek/adapter-event-store-memory` - In-memory event and snapshot storage
  - `@magek/adapter-read-model-store-memory` - In-memory read model store with full filter support
  - `@magek/adapter-session-store-memory` - In-memory session/subscription management
- Add comprehensive documentation guide for creating custom adapters (`docs/content/advanced/custom-adapters.md`)

## Test plan
- [x] All 67 new tests pass (18 event store, 30 read model store, 19 session store)
- [x] `rush build` succeeds
- [x] `rush lint:check` passes
- [x] `rush test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)