### PR TITLE
docs: fix decorator naming conventions in documentation

### DIFF
--- a/docs/content/advanced/data-migrations.md
+++ b/docs/content/advanced/data-migrations.md
@@ -22,7 +22,7 @@ For example, to upgrade a `Product` entity from version 1 to version 2, you can 
 ```typescript
 @SchemaMigration(Product)
 export class ProductMigration {
-  @ToVersion(2, { fromSchema: ProductV1, toSchema: ProductV2 })
+  @toVersion(2, { fromSchema: ProductV1, toSchema: ProductV2 })
   public async changeNameFieldToDisplayName(old: ProductV1): Promise<ProductV2> {
     return new ProductV2(
       old.id,
@@ -37,9 +37,9 @@ export class ProductMigration {
 }
 ```
 
-Notice that we've used the `@ToVersion` decorator in the above example. This decorator not only tells Magek what schema upgrade this migration performs, it also informs it about the existence of a version, which is always an integer number. Magek will always use the latest version known to tag newly created artifacts, defaulting to 1 when no migrations are defined. This ensures that the schema of newly created events and entities is up-to-date and that they can be migrated as needed in the future.
+Notice that we've used the `@toVersion` decorator in the above example. This decorator not only tells Magek what schema upgrade this migration performs, it also informs it about the existence of a version, which is always an integer number. Magek will always use the latest version known to tag newly created artifacts, defaulting to 1 when no migrations are defined. This ensures that the schema of newly created events and entities is up-to-date and that they can be migrated as needed in the future.
 
-The `@ToVersion` decorator takes two parameters in addition to the version: `fromSchema` and `toSchema`. The fromSchema parameter is set to `ProductV1`, while the `toSchema` parameter is set to `ProductV2`. This tells Magek that the migration is updating the `Product` object from version 1 (as defined by the `ProductV1` schema) to version 2 (as defined by the `ProductV2` schema).
+The `@toVersion` decorator takes two parameters in addition to the version: `fromSchema` and `toSchema`. The fromSchema parameter is set to `ProductV1`, while the `toSchema` parameter is set to `ProductV2`. This tells Magek that the migration is updating the `Product` object from version 1 (as defined by the `ProductV1` schema) to version 2 (as defined by the `ProductV2` schema).
 
 As Magek can easily read the structure of your classes, the schemas are described as plain classes that you can maintain as part of your code. The `ProductV1` class represents the schema of the previous version of the `Product` object with the properties and structure of the `Product` object as it was defined in version 1. The `ProductV2` class is an alias for the latest version of the Product object. You can use the `Product` class here, there's no difference, but it's a good practice to create an alias for clarity.
 
@@ -61,12 +61,12 @@ class ProductV1 {
 class ProductV2 extends Product {}
 ```
 
-When you want to upgrade your artifacts from V2 to V3, you can add a new function decorated with `@ToVersion` to the same migrations class. You're free to structure the code the way you want, but we recommend keeping all migrations for the same artifact in the same migration class. For instance:
+When you want to upgrade your artifacts from V2 to V3, you can add a new function decorated with `@toVersion` to the same migrations class. You're free to structure the code the way you want, but we recommend keeping all migrations for the same artifact in the same migration class. For instance:
 
 ```typescript
 @SchemaMigration(Product)
 export class ProductMigration {
-  @ToVersion(2, { fromSchema: ProductV1, toSchema: ProductV2 })
+  @toVersion(2, { fromSchema: ProductV1, toSchema: ProductV2 })
   public async changeNameFieldToDisplayName(old: ProductV1): Promise<ProductV2> {
     return new ProductV2(
       old.id,
@@ -79,7 +79,7 @@ export class ProductMigration {
     )
   }
 
-  @ToVersion(3, { fromSchema: ProductV2, toSchema: ProductV3 })
+  @toVersion(3, { fromSchema: ProductV2, toSchema: ProductV3 })
   public async addNewField(old: ProductV2): Promise<ProductV3> {
     return new ProductV3(
       old.id,

--- a/docs/content/architecture/command.md
+++ b/docs/content/architecture/command.md
@@ -26,10 +26,10 @@ In Magek you define them as TypeScript classes decorated with the `@Command` dec
   authorize: 'all',
 })
 export class CommandName {
-  @Field()
+  @field()
   readonly fieldA!: SomeType
 
-  @Field()
+  @field()
   readonly fieldB!: SomeOtherType
 }
 ```
@@ -41,10 +41,10 @@ These commands are handled by `Command Handlers`, the same way a **REST Controll
   authorize: 'all',
 })
 export class CommandName {
-  @Field()
+  @field()
   readonly fieldA!: SomeType
 
-  @Field()
+  @field()
   readonly fieldB!: SomeOtherType
 
   // highlight-start
@@ -74,10 +74,10 @@ Within the command handler execution, it is possible to register domain events. 
   authorize: 'all',
 })
 export class CreateProduct {
-  @Field()
+  @field()
   readonly sku!: string
 
-  @Field()
+  @field()
   readonly price!: number
 
   public static async handle(command: CreateProduct, register: Register): Promise<string> {
@@ -102,10 +102,10 @@ For example:
   authorize: 'all',
 })
 export class CreateProduct {
-  @Field()
+  @field()
   readonly sku!: string
 
-  @Field()
+  @field()
   readonly price!: number
 
   public static async handle(command: CreateProduct, register: Register): Promise<string> {
@@ -131,10 +131,10 @@ One case where you might want to throw an error is when the command is invalid b
   authorize: 'all',
 })
 export class CreateProduct {
-  @Field()
+  @field()
   readonly sku!: string
 
-  @Field()
+  @field()
   readonly price!: number
 
   public static async handle(command: CreateProduct, register: Register): Promise<void> {
@@ -169,16 +169,16 @@ There could be situations in which you want to register an event representing an
   authorize: 'all',
 })
 export class MoveStock {
-  @Field()
+  @field()
   readonly productID!: string
 
-  @Field()
+  @field()
   readonly origin!: string
 
-  @Field()
+  @field()
   readonly destination!: string
 
-  @Field()
+  @field()
   readonly quantity!: number
 
   public static async handle(command: MoveStock, register: Register): Promise<void> {
@@ -207,16 +207,16 @@ Event handlers are a good place to make decisions and, to make better decisions,
   authorize: 'all',
 })
 export class MoveStock {
-  @Field()
+  @field()
   readonly productID!: string
 
-  @Field()
+  @field()
   readonly origin!: string
 
-  @Field()
+  @field()
   readonly destination!: string
 
-  @Field()
+  @field()
   readonly quantity!: number
 
   public static async handle(command: MoveStock, register: Register): Promise<void> {
@@ -244,16 +244,16 @@ Commands are part of the public API of a Magek application, so you can define wh
   authorize: 'all',
 })
 export class CreateProduct {
-  @Field()
+  @field()
   readonly sku!: Sku
 
-  @Field()
+  @field()
   readonly displayName!: string
 
-  @Field()
+  @field()
   readonly description!: string
 
-  @Field()
+  @field()
   readonly price!: number
 
   public static async handle(command: CreateProduct, register: Register): Promise<void> {
@@ -275,16 +275,16 @@ Magek automatically creates one mutation per command. The framework infers the m
   authorize: 'all',
 })
 export class CreateProduct {
-  @Field()
+  @field()
   readonly sku!: Sku
 
-  @Field()
+  @field()
   readonly displayName!: string
 
-  @Field()
+  @field()
   readonly description!: string
 
-  @Field()
+  @field()
   readonly price!: number
 
   public static async handle(command: CreateProduct, register: Register): Promise<void> {

--- a/docs/content/architecture/entity.md
+++ b/docs/content/architecture/entity.md
@@ -28,35 +28,35 @@ To declare an entity in Magek, you must define a class decorated with the `@Enti
 ```typescript title="src/entities/entity-name.ts"
 @Entity
 export class EntityName {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly fieldA!: SomeType
 
-  @Field()
+  @field()
   readonly fieldB!: SomeOtherType
 }
 ```
 
 ## The reduce function
 
-In order to tell Magek how to reduce the events, you must define a static method decorated with the `@Reduces` decorator. This method will be called by the framework every time an event of the specified type is emitted. The reducer method must return a new entity instance with the current state of the entity.
+In order to tell Magek how to reduce the events, you must define a static method decorated with the `@reduces` decorator. This method will be called by the framework every time an event of the specified type is emitted. The reducer method must return a new entity instance with the current state of the entity.
 
 ```typescript title="src/entities/entity-name.ts"
 @Entity
 export class EntityName {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly fieldA!: SomeType
 
-  @Field()
+  @field()
   readonly fieldB!: SomeOtherType
 
   // highlight-start
-  @Reduces(SomeEvent)
+  @reduces(SomeEvent)
   public static reduceSomeEvent(event: SomeEvent, currentEntityState?: EntityName): EntityName {
     return evolve(currentEntityState, {
       id: event.entityID(),
@@ -73,6 +73,8 @@ The reducer method receives two parameters:
 - `event` - The event object that triggered the reducer
 - `currentEntity?` - The current state of the entity instance that the event belongs to if it exists. **This parameter is optional** and will be `undefined` if the entity doesn't exist yet (For example, when you process a `ProductCreated` event that will generate the first version of a `Product` entity).
 
+> **Tip:** The `evolve()` helper function creates a new immutable copy of the entity with the specified field updates. It safely handles the case where `currentEntityState` is `undefined` (for newly created entities) and ensures immutability by returning a fresh object rather than mutating the existing one.
+
 ### Reducing multiple events
 
 You can define as many reducer methods as you want, each one for a different event type. For example, if you have a `Cart` entity, you could define a reducer for `ProductAdded` events and another one for `ProductRemoved` events.
@@ -80,19 +82,19 @@ You can define as many reducer methods as you want, each one for a different eve
 ```typescript title="src/entities/cart.ts"
 @Entity
 export class Cart {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly items!: Array<CartItem>
 
-  @Reduces(ProductAdded)
+  @reduces(ProductAdded)
   public static reduceProductAdded(event: ProductAdded, currentCart?: Cart): Cart {
     const newItems = addToCart(event.item, currentCart)
     return evolve(currentCart, { id: event.entityID(), items: newItems })
   }
 
-  @Reduces(ProductRemoved)
+  @reduces(ProductRemoved)
   public static reduceProductRemoved(event: ProductRemoved, currentCart?: Cart): Cart {
     const newItems = removeFromCart(event.item, currentCart)
     return evolve(currentCart, { items: newItems })
@@ -116,16 +118,16 @@ import { ReducerAction, ReducerResult } from '@magek/common'
 
 @Entity
 export class Product {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly name!: string
 
-  @Field()
+  @field()
   readonly price!: number
 
-  @Reduces(ProductUpdated)
+  @reduces(ProductUpdated)
   public static reduceProductUpdated(
     event: ProductUpdated,
     currentProduct?: Product
@@ -164,16 +166,16 @@ In order to identify each entity instance, you must define an `id` field on each
 @Entity
 export class EntityName {
   // highlight-next-line
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly fieldA!: SomeType
 
-  @Field()
+  @field()
   readonly fieldB!: SomeOtherType
 
-  @Reduces(SomeEvent)
+  @reduces(SomeEvent)
   public static reduceSomeEvent(event: SomeEvent, currentEntityState?: EntityName): EntityName {
     return evolve(currentEntityState, {
       id: event.entityID(),

--- a/docs/content/architecture/event.md
+++ b/docs/content/architecture/event.md
@@ -24,10 +24,10 @@ Events are the cornerstone of Magek because of its event-driven and event-source
 ```typescript title="src/events/event-name.ts"
 @Event
 export class EventName {
-  @Field()
+  @field()
   public readonly field1!: SomeType
 
-  @Field()
+  @field()
   public readonly field2!: SomeOtherType
 
   public constructor(field1: SomeType, field2: SomeOtherType) {
@@ -50,10 +50,10 @@ Events and [Entities](./entity.md) are closely related. Each event will be aggre
 ```typescript title="src/events/cart-paid.ts"
 @Event
 export class CartPaid {
-  @Field()
+  @field()
   public readonly cartID!: UUID
 
-  @Field()
+  @field()
   public readonly paymentID!: UUID
 
   public constructor(cartID: UUID, paymentID: UUID) {
@@ -86,16 +86,16 @@ We have shown you how to _declare_ an event in Magek, but we haven't explained h
   authorize: [Admin],
 })
 export class MoveStock {
-  @Field()
+  @field()
   readonly productID!: string
 
-  @Field()
+  @field()
   readonly origin!: string
 
-  @Field()
+  @field()
   readonly destination!: string
 
-  @Field()
+  @field()
   readonly quantity!: number
 
   public static async handle(command: MoveStock, register: Register): Promise<void> {

--- a/docs/content/architecture/queries.md
+++ b/docs/content/architecture/queries.md
@@ -21,11 +21,11 @@ import {
   authorize: 'all',
 })
 export class CartTotalQuantity {
-  @Field()
+  @field()
   readonly cartId!: UUID
 
-  @Field()
-  @NonExposed
+  @field()
+  @nonExposed
   readonly multiply!: number
 
   public static async handle(query: CartTotalQuantity, queryInfo: QueryInfo): Promise<number> {
@@ -107,7 +107,7 @@ For every query, Magek automatically creates the corresponding GraphQL query. Fo
   authorize: 'all',
 })
 export class CartTotalQuantityQuery {
-  @Field()
+  @field()
   readonly cartId!: UUID
 
   public static async handle(query: CartTotalQuantity, queryInfo: QueryInfo): Promise<number> {
@@ -149,7 +149,7 @@ class SearchResult {
   authorize: 'all',
 })
 export class SearchMedia {
-  @Field()
+  @field()
   readonly searchword!: string
 
   public static async handle(query: SearchMedia, queryInfo: QueryInfo): Promise<SearchResult> {

--- a/docs/content/architecture/read-model.md
+++ b/docs/content/architecture/read-model.md
@@ -28,13 +28,13 @@ In Magek, a read model is a class decorated with the `@ReadModel` decorator. The
   authorize: 'all',
 })
 export class ReadModelName {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly fieldA!: SomeType
 
-  @Field()
+  @field()
   readonly fieldB!: SomeType
 }
 ```
@@ -43,29 +43,29 @@ export class ReadModelName {
 
 ## The projection function
 
-The projection function is a static method decorated with the `@Projects` decorator. It is used to define how the read model is updated when an entity is modified. he projection function must return a new instance of the read model, it receives two arguments:
+The projection function is a static method decorated with the `@projects` decorator. It is used to define how the read model is updated when an entity is modified. he projection function must return a new instance of the read model, it receives two arguments:
 
 - `entity`: The entity that has been modified
 - `current?`: The current read model instance. If it's the first time the read model is created, this argument will be `undefined`
 
-You must provide the `@Projects` decorator with an entity class and the **_join key_**. The join key is the name of the field in the entity that is used to match it with the read model's `id` field. In the example below, we are using the `id` field of the `Cart` entity to match it with the `CartReadModel` read model.
+You must provide the `@projects` decorator with an entity class and the **_join key_**. The join key is the name of the field in the entity that is used to match it with the read model's `id` field. In the example below, we are using the `id` field of the `Cart` entity to match it with the `CartReadModel` read model.
 
 ```typescript
 @ReadModel({
   authorize: 'all',
 })
 export class CartReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly cartItems!: Array<CartItem>
 
-  @Field()
+  @field()
   readonly paid!: boolean
 
   // highlight-start
-  @Projects(Cart, 'id')
+  @projects(Cart, 'id')
   public static projectCart(entity: Cart, currentCartReadModel?: CartReadModel): CartReadModel {
     return evolve(currentCartReadModel, {
       id: entity.id,
@@ -86,20 +86,20 @@ You are able to project multiple entities into the same read model. For example,
   authorize: 'all',
 })
 export class UserReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly username!: string
 
   // highlight-next-line
-  @Projects(User, 'id')
+  @projects(User, 'id')
   public static projectUser(entity: User, current?: UserReadModel): ProjectionResult<UserReadModel> {
     // Here we update the user fields
   }
 
   // highlight-next-line
-  @Projects(Post, 'ownerId')
+  @projects(Post, 'ownerId')
   public static projectUserPost(entity: Post, current?: UserReadModel): ProjectionResult<UserReadModel> {
     //Here we can adapt the read model to show specific user information related with the Post entity
   }
@@ -115,7 +115,7 @@ There might be cases where you need to project an entity into a read model using
 You can use an array of entities as a join key. For example, if you have a `Group` entity with an array of users in that group (`users: Array<UUID>`), you can have the following to update each `UserReadModel` accordingly:
 
 ```typescript
-  @Projects(Group, 'users')
+  @projects(Group, 'users')
   public static projectUserGroup(entity: Group, readModelID: UUID, current?: UserReadModel): ProjectionResult<UserReadModel> {
     //Here we can update the read models with group information
     //This logic will be executed for each read model id in the array
@@ -125,7 +125,7 @@ You can use an array of entities as a join key. For example, if you have a `Grou
 You can even select arrays of UUIDs as `joinKey`. Magek get each value on the array, find a read model with that id and execute the projection function. The signature of the projection function is a bit different in this case. It receives the `readModelID` as the second argument, which is the id we are projecting from the array. The third argument is the current read model instance, which will be `undefined` if it's the first time the read model is created. For example, if we have a `Group` with an array of users in that group (`users: Array<UUID>`), we can have the following to update each `UserReadModel` accordingly:
 
 ```typescript
-  @Projects(Group, 'users')
+  @projects(Group, 'users')
   public static projectUserGroup(entity: Group, readModelID: UUID, current?: UserReadModel): ProjectionResult<UserReadModel> {
     //Here we can update the read models with group information
     //This logic will be executed for each read model id in the array
@@ -141,16 +141,16 @@ You can use a read model query as a join key to get all the read models that mat
   authorize: 'all',
 })
 export class CarPurchasesReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly carModel?: string
 
-  @Field()
+  @field()
   readonly carOwner?: string
 
-  @Field()
+  @field()
   readonly offers?: Array<CarOffers>
 
   // rest of the code
@@ -164,19 +164,19 @@ If a car model changed its name (or any other property of such an entity that's 
   authorize: 'all',
 })
 export class CarPurchasesReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly carModel?: CarModel
 
-  @Field()
+  @field()
   readonly carOwner?: CarOwner
 
-  @Field()
+  @field()
   readonly offers?: Array<CarOffers>
 
-  @Projects(CarModel, (carModel: CarModel): FilterFor<CarPurchasesReadModel> => {
+  @projects(CarModel, (carModel: CarModel): FilterFor<CarPurchasesReadModel> => {
     return {
       carModel: {
         id: {
@@ -224,13 +224,13 @@ One of the most common cases is when you want to delete a read model. For exampl
   authorize: 'all',
 })
 export class UserReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly username!: string
 
-  @Projects(User, 'id')
+  @projects(User, 'id')
   public static projectUser(entity: User, current?: UserReadModel): ProjectionResult<UserReadModel>  {
     if (entity.deleted) {
       return ReadModelAction.Delete
@@ -250,13 +250,13 @@ Another common case is when you want to keep the read model untouched. For examp
   authorize: 'all',
 })
 export class UserReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly username!: string
 
-  @Projects(User, 'id')
+  @projects(User, 'id')
   public static projectUser(entity: User, current?: UserReadModel): ProjectionResult<UserReadModel>  {
     if (!entity.modified) {
       return ReadModelAction.Nothing
@@ -271,7 +271,7 @@ export class UserReadModel {
 
 You can use TypeScript getters in your read models to allow nested queries and/or return calculated values. You can write arbitrary code in a getter, but you will typically query for related read model objects or generate a value computed based on the current read model instance or context. This greatly improves the potential of customizing your read model responses.
 
-> **Info:** Starting version 2.13, getters for values which are calculated using other properties of the read model need to be annotated with the `@CalculatedField` decorator and a list of those properties as dependencies.
+> **Info:** Starting version 2.13, getters for values which are calculated using other properties of the read model need to be annotated with the `@calculatedField` decorator and a list of those properties as dependencies.
 
 Here's an example of a getter in the `UserReadModel` class that returns all `PostReadModel`s that belong to a specific `UserReadModel`:
 
@@ -280,15 +280,15 @@ Here's an example of a getter in the `UserReadModel` class that returns all `Pos
   authorize: 'all',
 })
 export class UserReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly name!: string
 
   private postIds!: UUID[]
 
-  @CalculatedField({ dependsOn: ['postIds'] })
+  @calculatedField({ dependsOn: ['postIds'] })
   public get posts(): Promise<PostReadModel[]> {
     return this.postIds.map((postId) => Magek.readModel(PostReadModel)
       .filter({
@@ -297,7 +297,7 @@ export class UserReadModel {
       .search()
   }
 
-  @Projects(User, 'id')
+  @projects(User, 'id')
   public static projectUser(entity: User, current?: UserReadModel): ProjectionResult<UserReadModel>  {
     return evolve(current, { id: entity.id, name: entity.name, postIds: entity.postIds })
   }
@@ -368,19 +368,19 @@ Read models are part of the public API of a Magek application, so you can define
   authorize: 'all',
 })
 export class ProductReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly name!: string
 
-  @Field()
+  @field()
   readonly description!: string
 
-  @Field()
+  @field()
   readonly price!: number
 
-  @Projects(Product, 'id')
+  @projects(Product, 'id')
   public static projectProduct(entity: Product, current?: ProductReadModel): ProjectionResult<ProductReadModel> {
     return evolve(current, {
       id: entity.id,
@@ -405,13 +405,13 @@ Magek automatically creates the queries and subscriptions for each read model. Y
   authorize: 'all',
 })
 export class CartReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly items!: Array<CartItem>
 
-  @Projects(Cart, 'id')
+  @projects(Cart, 'id')
   public static projectCart(entity: Cart, currentReadModel?: CartReadModel): ProjectionResult<CartReadModel> {
     return evolve(currentReadModel, { id: entity.id, items: entity.items })
   }
@@ -445,17 +445,17 @@ There are some cases when it's desirable to query your read models sorted a part
   authorize: 'all',
 })
 export class MessageReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   readonly id!: UUID // A channel ID
 
-  @Field()
+  @field()
   @sequencedBy
   readonly timestamp!: string
 
-  @Field()
+  @field()
   readonly contents!: string
 
-  @Projects(Message, 'id')
+  @projects(Message, 'id')
   public static projectMessage(
     entity: Message,
     currentReadModel?: MessageReadModel

--- a/docs/content/features/error-handling.md
+++ b/docs/content/features/error-handling.md
@@ -73,7 +73,7 @@ export class MyErrorHandler {
 
 ### Reducer errors
 
-These are the errors that are thrown in the `@Reduces` method of the `@Entity`. You can catch and return new errors in this function annotating a class with `@GlobalErrorHandler` and implementing the following method:
+These are the errors that are thrown in the `@reduces` method of the `@Entity`. You can catch and return new errors in this function annotating a class with `@GlobalErrorHandler` and implementing the following method:
 
 ```typescript
 @GlobalErrorHandler()
@@ -109,7 +109,7 @@ This method receives the error that was thrown and the event received.
 
 ### Projection errors
 
-These are the errors that are thrown in the `@Projects` method of the `@ReadModel`. You can catch and return new errors in this function annotating a class with `@GlobalErrorHandler` and implementing the following method:
+These are the errors that are thrown in the `@projects` method of the `@ReadModel`. You can catch and return new errors in this function annotating a class with `@GlobalErrorHandler` and implementing the following method:
 
 ```typescript
 @GlobalErrorHandler()

--- a/docs/content/features/logging.md
+++ b/docs/content/features/logging.md
@@ -58,10 +58,10 @@ _Example: Obtaining a logger for your command:_
   authorize: [User],
 })
 export class UpdateShippingAddress {
-  @Field()
+  @field()
   readonly cartId!: UUID
 
-  @Field()
+  @field()
   readonly address!: Address
 
   public static async handle(command: UpdateShippingAddress, register: Register): Promise<void> {

--- a/docs/content/getting-started/coding.md
+++ b/docs/content/getting-started/coding.md
@@ -154,16 +154,16 @@ To do that, open the file we have just generated and add the string `'all'` to t
   authorize: 'all', // Specify authorized roles here. Use 'all' to authorize anyone
 })
 export class CreatePost {
-  @Field()
+  @field()
   readonly postId!: UUID
 
-  @Field()
+  @field()
   readonly title!: string
 
-  @Field()
+  @field()
   readonly content!: string
 
-  @Field()
+  @field()
   readonly author!: string
 
   public static async handle(command: CreatePost, register: Register): Promise<void> {
@@ -203,16 +203,16 @@ to return our `postID`:
 
 @Event
 export class PostCreated {
-  @Field()
+  @field()
   public readonly postId!: UUID
 
-  @Field()
+  @field()
   public readonly title!: string
 
-  @Field()
+  @field()
   public readonly content!: string
 
-  @Field()
+  @field()
   public readonly author!: string
 
   public constructor(postId: UUID, title: string, content: string, author: string) {
@@ -269,19 +269,19 @@ from the event. There is no previous state of the Post as we are creating it for
 // src/entities/post.ts
 @Entity
 export class Post {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly title!: string
 
-  @Field()
+  @field()
   readonly content!: string
 
-  @Field()
+  @field()
   readonly author!: string
 
-  @Reduces(PostCreated)
+  @reduces(PostCreated)
   public static reducePostCreated(event: PostCreated, currentPost?: Post): Post {
     return evolve(currentPost, {
       id: event.postId,
@@ -342,16 +342,16 @@ Edit the `post-read-model.ts` file to look like this:
   authorize: 'all', // Specify authorized roles here. Use 'all' to authorize anyone
 })
 export class PostReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   public id!: UUID
 
-  @Field()
+  @field()
   readonly title!: string
 
-  @Field()
+  @field()
   readonly author!: string
 
-  @Projects(Post, 'id')
+  @projects(Post, 'id')
   public static projectPost(entity: Post, currentPostReadModel?: PostReadModel): ProjectionResult<PostReadModel> {
     return evolve(currentPostReadModel, {
       id: entity.id,

--- a/docs/content/graphql.md
+++ b/docs/content/graphql.md
@@ -27,10 +27,10 @@ The GraphQL API is fully **auto-generated** based on your _commands_ and _read m
 // My type
 export class ItemWithQuantity {
   // Use "class", not "interface"
-  @Field()
+  @field()
   sku!: string
 
-  @Field()
+  @field()
   quantity!: number
 }
 ```
@@ -41,10 +41,10 @@ export class ItemWithQuantity {
   authorize: 'all'
 })
 export class CartReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   readonly id!: UUID
 
-  @Field()
+  @field()
   item!: ItemWithQuantity // As ItemWithQuantity is a class, you will be able to query over nested attributes like item `quantity`
 ```
 
@@ -332,7 +332,7 @@ mutation {
 
 ## Non exposing properties and parameters
 
-By default, all properties and parameters of the command constructor and/or read model are accessible through GraphQL. It is possible to not expose any of them adding the `@NonExposed` annotation to the constructor property or parameter.
+By default, all properties and parameters of the command constructor and/or read model are accessible through GraphQL. It is possible to not expose any of them adding the `@nonExposed` annotation to the constructor property or parameter.
 
 Example
 ```typescript
@@ -340,29 +340,29 @@ Example
   authorize: 'all',
 })
 export class CartReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   readonly id!: UUID
 
-  @Field()
+  @field()
   readonly cartItems!: Array<CartItem>
 
-  @Field()
+  @field()
   readonly checks!: number
 
-  @Field()
+  @field()
   public shippingAddress?: Address
 
-  @Field()
+  @field()
   public payment?: Payment
 
-  @Field()
+  @field()
   public cartItemsIds?: Array<string>
 
-  @NonExposed
+  @nonExposed
   private internalProperty?: number
 
-  @Field()
-  @NonExposed
+  @field()
+  @nonExposed
   readonly internalParameter?: number
 }
 ```
@@ -398,10 +398,10 @@ In order to define a before hook you pass a list of functions with the right sig
   before: [validateUser],
 })
 export class CartReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   readonly id!: UUID
 
-  @Field()
+  @field()
   readonly userId!: UUID
 
   // Your projections go here
@@ -424,10 +424,10 @@ You can also define more than one `before` hook for a read model, and they will 
   before: [validateUser, validateEmail, changeFilters],
 })
 export class CartReadModel {
-  @Field(type => UUID)
+  @field(type => UUID)
   readonly id!: UUID
 
-  @Field()
+  @field()
   readonly userId!: UUID
 
   // Your projections go here
@@ -454,13 +454,13 @@ You can use `before` hooks also in your command handlers, and [they work as the 
   before: [beforeFn],
 })
 export class ChangeCartItem {
-  @Field()
+  @field()
   readonly cartId!: UUID
 
-  @Field()
+  @field()
   readonly productId!: UUID
 
-  @Field()
+  @field()
   readonly quantity!: number
 }
 
@@ -484,11 +484,11 @@ You can use `before` hooks also in your queries, and [they work as the Read Mode
   before: [CartTotalQuantity.beforeFn],
 })
 export class CartTotalQuantity {
-  @Field()
+  @field()
   readonly cartId!: UUID
 
-  @Field()
-  @NonExposed
+  @field()
+  @nonExposed
   readonly multiply!: number
 
   public static async beforeFn(input: QueryInput, currentUser?: UserEnvelope): Promise<QueryInput> {
@@ -820,7 +820,7 @@ For example, you can filter and get the total number of the products that meet y
   authorize: 'all',
 })
 export class GetProductsCount {
-  @Field()
+  @field()
   readonly filters!: Record<string, any>
 
   public static async handle(): Promise<void> {
@@ -851,7 +851,7 @@ You can select which fields you want to get in your read model using the `select
   authorize: 'all',
 })
 export class GetProductsCount {
-  @Field()
+  @field()
   readonly filters!: Record<string, any>
 
   public static async handle(): Promise<unknown> {
@@ -882,7 +882,7 @@ You can also select properties in objects which are part of an array property in
   authorize: 'all',
 })
 export class GetCartItems {
-  @Field()
+  @field()
   readonly filters!: Record<string, any>
 
   public static async handle(): Promise<unknown> {

--- a/docs/content/security/authorization.md
+++ b/docs/content/security/authorization.md
@@ -222,19 +222,19 @@ const CustomEventAuthorizer: EventStreamAuthorizer = async (currentUser, eventSe
   authorizeReadEvents: CustomEventAuthorizer
 })
 export class Cart {
-  @Field(type => UUID)
+  @field(type => UUID)
   readonly id!: UUID
 
-  @Field()
+  @field()
   readonly ownerUserName!: string
 
-  @Field()
+  @field()
   readonly cartItems!: Array<CartItem>
 
-  @Field()
+  @field()
   public shippingAddress?: Address
 
-  @Field()
+  @field()
   public checks: number = 0
 
   // ... reducers


### PR DESCRIPTION
## Summary

- Fix method/property decorator naming to use camelCase (matching source code conventions):
  - `@Field` → `@field`
  - `@Reduces` → `@reduces`
  - `@Projects` → `@projects`
  - `@CalculatedField` → `@calculatedField`
  - `@NonExposed` → `@nonExposed`
  - `@ToVersion` → `@toVersion`
- Add explanation of the `evolve()` helper function in entity.md

## Test plan

- [ ] Verify documentation builds correctly
- [ ] Review code examples for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)