### PR TITLE
fix(core): include request context in read model envelopes

### DIFF
--- a/common/changes/@magek/core/fix-read-model-authorizers-issue_2026-02-05-22-02.json
+++ b/common/changes/@magek/core/fix-read-model-authorizers-issue_2026-02-05-22-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@magek/core",
+      "comment": "Include request context (headers, body) in read model request envelopes so authorizers can access HTTP headers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@magek/core"
+}

--- a/packages/core/src/services/graphql/graphql-generator.ts
+++ b/packages/core/src/services/graphql/graphql-generator.ts
@@ -227,7 +227,7 @@ export class GraphQLGenerator {
           body: context.context?.request.body,
           headers: context.context?.request.headers,
         },
-        rawContext: context,
+        rawContext: context.context?.rawContext,
       },
     }
   }
@@ -382,7 +382,7 @@ function toReadModelRequestEnvelope(
         body: context.context?.request.body,
         headers: context.context?.request.headers,
       },
-      rawContext: context,
+      rawContext: context.context?.rawContext,
     },
   }
 }

--- a/packages/core/src/services/graphql/graphql-generator.ts
+++ b/packages/core/src/services/graphql/graphql-generator.ts
@@ -222,6 +222,13 @@ export class GraphQLGenerator {
       version: 1, // TODO: How to pass the version through GraphQL?
       filters: {},
       sortBy: {},
+      context: {
+        request: {
+          body: context.context?.request.body,
+          headers: context.context?.request.headers,
+        },
+        rawContext: context,
+      },
     }
   }
 
@@ -370,6 +377,13 @@ function toReadModelRequestEnvelope(
     paginatedVersion,
     version: 1, // TODO: How to pass the version through GraphQL?
     select,
+    context: {
+      request: {
+        body: context.context?.request.body,
+        headers: context.context?.request.headers,
+      },
+      rawContext: context,
+    },
   }
 }
 

--- a/packages/core/test/services/graphql/graphql-generator.test.ts
+++ b/packages/core/test/services/graphql/graphql-generator.test.ts
@@ -197,7 +197,7 @@ describe('GraphQL generator', () => {
                 query: 'Test query',
               },
             },
-            rawContext: mockResolverContext,
+            rawContext: mockResolverContext.context?.rawContext,
           },
         }
 
@@ -240,6 +240,7 @@ describe('GraphQL generator', () => {
 
           const fakeArgs = { id: '42' }
           const fakeUser = { a: 'user' }
+          const fakeRawContext = { raw: 'http-request' }
           const fakeContext: any = {
             user: fakeUser,
             requestID: '314',
@@ -248,6 +249,7 @@ describe('GraphQL generator', () => {
                 headers: { authorization: 'Bearer test-token' },
                 body: { query: 'test query' },
               },
+              rawContext: fakeRawContext,
             },
           }
           await returnedFunction({}, fakeArgs, fakeContext, {} as any)
@@ -267,7 +269,7 @@ describe('GraphQL generator', () => {
               headers: { authorization: 'Bearer test-token' },
               body: { query: 'test query' },
             },
-            rawContext: fakeContext,
+            rawContext: fakeRawContext,
           })
 
           expect(fakeFindById).to.have.been.calledOnceWith(envelope)
@@ -288,6 +290,7 @@ describe('GraphQL generator', () => {
 
           const fakeArgs = { id: '42', timestamp: '1000' }
           const fakeUser = { a: 'user' }
+          const fakeRawContext = { raw: 'http-request' }
           const fakeContext: any = {
             user: fakeUser,
             requestID: '314',
@@ -296,6 +299,7 @@ describe('GraphQL generator', () => {
                 headers: { authorization: 'Bearer test-token' },
                 body: { query: 'test query' },
               },
+              rawContext: fakeRawContext,
             },
           }
           await returnedFunction({}, fakeArgs, fakeContext, {} as any)
@@ -319,7 +323,7 @@ describe('GraphQL generator', () => {
               headers: { authorization: 'Bearer test-token' },
               body: { query: 'test query' },
             },
-            rawContext: fakeContext,
+            rawContext: fakeRawContext,
           })
 
           expect(fakeFindById).to.have.been.calledOnceWith(envelope)
@@ -558,7 +562,7 @@ describe('GraphQL generator', () => {
                 query: 'Test query',
               },
             },
-            rawContext: mockResolverContext,
+            rawContext: mockResolverContext.context?.rawContext,
           },
         })
       })

--- a/packages/core/test/services/graphql/graphql-generator.test.ts
+++ b/packages/core/test/services/graphql/graphql-generator.test.ts
@@ -188,6 +188,17 @@ describe('GraphQL generator', () => {
           paginatedVersion: false,
           version: 1,
           select: undefined,
+          context: {
+            request: {
+              headers: {
+                authorization: 'Bearer 123',
+              },
+              body: {
+                query: 'Test query',
+              },
+            },
+            rawContext: mockResolverContext,
+          },
         }
 
         await returnedFunction('', {}, mockResolverContext, { fieldNodes: [] } as any)
@@ -229,7 +240,16 @@ describe('GraphQL generator', () => {
 
           const fakeArgs = { id: '42' }
           const fakeUser = { a: 'user' }
-          const fakeContext: any = { user: fakeUser, requestID: '314' }
+          const fakeContext: any = {
+            user: fakeUser,
+            requestID: '314',
+            context: {
+              request: {
+                headers: { authorization: 'Bearer test-token' },
+                body: { query: 'test query' },
+              },
+            },
+          }
           await returnedFunction({}, fakeArgs, fakeContext, {} as any)
 
           expect(toReadModelByIdRequestEnvelopeSpy).to.have.been.calledOnceWith(SomeReadModel, fakeArgs, fakeContext)
@@ -242,6 +262,13 @@ describe('GraphQL generator', () => {
           expect(envelope.key).to.be.deep.equal({ id: '42' })
           expect(envelope.key.sequenceKey).to.be.undefined
           expect(envelope).to.have.property('version', 1)
+          expect(envelope.context).to.deep.equal({
+            request: {
+              headers: { authorization: 'Bearer test-token' },
+              body: { query: 'test query' },
+            },
+            rawContext: fakeContext,
+          })
 
           expect(fakeFindById).to.have.been.calledOnceWith(envelope)
         })
@@ -261,7 +288,16 @@ describe('GraphQL generator', () => {
 
           const fakeArgs = { id: '42', timestamp: '1000' }
           const fakeUser = { a: 'user' }
-          const fakeContext: any = { user: fakeUser, requestID: '314' }
+          const fakeContext: any = {
+            user: fakeUser,
+            requestID: '314',
+            context: {
+              request: {
+                headers: { authorization: 'Bearer test-token' },
+                body: { query: 'test query' },
+              },
+            },
+          }
           await returnedFunction({}, fakeArgs, fakeContext, {} as any)
 
           expect(toReadModelByIdRequestEnvelopeSpy).to.have.been.calledOnceWith(
@@ -278,8 +314,64 @@ describe('GraphQL generator', () => {
           expect(envelope).to.have.property('className', 'SomeReadModel')
           expect(envelope.key).to.be.deep.equal({ id: '42', sequenceKey: { name: 'timestamp', value: '1000' } })
           expect(envelope).to.have.property('version', 1)
+          expect(envelope.context).to.deep.equal({
+            request: {
+              headers: { authorization: 'Bearer test-token' },
+              body: { query: 'test query' },
+            },
+            rawContext: fakeContext,
+          })
 
           expect(fakeFindById).to.have.been.calledOnceWith(envelope)
+        })
+      })
+    })
+
+    describe('readModelResolverBuilder includes request context', () => {
+      it('should include request headers in the read model envelope', async () => {
+        const fakeSearch = stub().resolves([])
+        replace(MagekReadModelsReader.prototype, 'search', fakeSearch)
+
+        const returnedFunction = GraphQLGenerator.readModelResolverBuilder(mockType)
+        await returnedFunction('', {}, mockResolverContext, { fieldNodes: [] } as any)
+
+        const envelope = fakeSearch.firstCall.args[0]
+        expect(envelope.context).to.exist
+        expect(envelope.context.request.headers).to.deep.equal({
+          authorization: 'Bearer 123',
+        })
+        expect(envelope.context.request.body).to.deep.equal({
+          query: 'Test query',
+        })
+      })
+    })
+
+    describe('readModelByIDResolverBuilder includes request context', () => {
+      class ContextTestReadModel {
+        @field()
+        public readonly id: string
+
+        public constructor(id: string) {
+          this.id = id
+        }
+      }
+
+      it('should include request headers in the read model by ID envelope', async () => {
+        const config = new MagekConfig('test')
+        const toReadModelByIdRequestEnvelopeSpy = spy(GraphQLGenerator as any, 'toReadModelByIdRequestEnvelope')
+        const fakeFindById = fake()
+        replace((GraphQLGenerator as any).readModelsReader, 'findById', fakeFindById)
+
+        const returnedFunction = GraphQLGenerator.readModelByIDResolverBuilder(config, ContextTestReadModel)
+        await returnedFunction({}, { id: '1' }, mockResolverContext, {} as any)
+
+        const envelope = toReadModelByIdRequestEnvelopeSpy.returnValues[0]
+        expect(envelope.context).to.exist
+        expect(envelope.context.request.headers).to.deep.equal({
+          authorization: 'Bearer 123',
+        })
+        expect(envelope.context.request.body).to.deep.equal({
+          query: 'Test query',
         })
       })
     })
@@ -457,6 +549,17 @@ describe('GraphQL generator', () => {
           paginatedVersion: false,
           version: 1,
           select: undefined,
+          context: {
+            request: {
+              headers: {
+                authorization: 'Bearer 123',
+              },
+              body: {
+                query: 'Test query',
+              },
+            },
+            rawContext: mockResolverContext,
+          },
         })
       })
 


### PR DESCRIPTION
## Summary

- **Fixes #759**: ReadModel authorizers were not receiving HTTP request headers because `toReadModelRequestEnvelope()` and `toReadModelByIdRequestEnvelope()` omitted the `context` property
- Added the `context` property (with `request.headers`, `request.body`, and `rawContext`) to both functions, matching the existing pattern in `toEnvelope()` used by commands
- Updated existing tests and added dedicated tests verifying headers flow through read model envelopes

## Test plan

- [x] `rush build -t @magek/core` compiles successfully
- [x] `rushx test` — all 329 tests pass
- [x] `rushx lint:check` — no new lint errors
- [ ] Verify authorizers receive headers in a real read model query

🤖 Generated with [Claude Code](https://claude.com/claude-code)